### PR TITLE
RFC: Templates — Reusable packages to share dependencies and configuration

### DIFF
--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -294,7 +294,15 @@ Usage of an template package is localized to a monorepo. When a package within t
 
 This allows the published `package.json` to be portable and consumed by other package managers.
 
-A command to view the rendered result will be available to assist debugging.
+### Debugging and Tracing
+
+A command to view the rendered result will be available to assist debugging. When `pnpm template view` is ran, the `package.json` file in the current working directory will be rendered. The `--trace` flag will show which template a field value was chosen from.
+
+```
+❯ pnpm template view --trace
+```
+
+<img width="1050" alt="Screenshot of pnpm view template command" src="https://github.com/pnpm/rfcs/assets/906558/7350f337-5b5a-4725-aa1a-e65bb367f31d">
 
 ## Prior Art
 

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -182,12 +182,14 @@ A package referencing the `@example/frontend-catalog` above will have the follow
   "name": "@example/react-components",
   "pnpm": {
     "templates": {
-      "catalog": ["@example/frontend-catalog@0.1.0"],
+      "catalog": {
+        "example-frontend": "@example/frontend-catalog@0.1.0"
+      }
     }
   },
   "dependencies": {
-    "react": "catalog:",
-    "redux": "catalog:"
+    "react": "catalog:example-frontend",
+    "redux": "catalog:example-frontend"
   }
 }
 ```

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -206,6 +206,11 @@ A package referencing the `@example/frontend-catalog` above will have the follow
 
 We expect the `pnpm.templates.catalog` flavor to very popular for monorepos. This allows dependency specifiers to be consistent between different in-repo packages.
 
+There are a few rules on how a catalog defines shared dependencies specifiers and how they can be consumed.
+
+- The `dependencies` block of a catalog can be used in the `dependencies`, `devDependencies`, and `optionalDependencies` of a consuming `package.json`.
+- The `peerDependencies` block of a catalog can only be used in the `peerDependencies` block of a consuming `package.json`.
+
 ### Compatibility and Patches
 
 The `compatibility` and `patches` template flavors apply to the root `package.json` of a pnpm workspace and allow modifications to the dependency graph.

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -336,7 +336,7 @@ importers:
 templates:
 
   /@example/frontend-catalog@0.1.0:
-    manifestResolution: {integrity: sha512...}
+    resolution: {integrity: sha512...}
     pnpm:
       template: catalog
     dependencies:
@@ -360,7 +360,7 @@ packages:
   # ...
 ```
 
-Since an integrity checksum of only the manifest is not provided by the registry, a new `manifestResolution.integrity` value will need to be computed locally.
+Similar to external dependencies under the `packages` block, external templates will store the `resolution.integrity` field provided from the registry in its lockfile entry. Note that only the `patches` template flavor actually uses the tarball associated with the integrity hash. The other template flavors will store the tarball integrity for consistency.
 
 In the initial implementation, `importers` entries referencing a template will have their rendered result saved to the lockfile.
 

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -245,6 +245,58 @@ Templates can be specified through:
 2. The `name@workspace:` syntax to refer to a template that's also a workspace package.
 3. The `file:<path>` syntax to refer to an on-disk path.
 
+### Shared Workspace Configuration
+
+It can be tedious to set up the same template configurations for each package in a pnpm workspace. The `workspaceTemplateConfigs` option can be specified at the root `package.json` to simplify.
+
+```json5
+// packages.json
+{
+  "pnpm": {
+    "workspaceTemplateConfigs": {
+      // All packages in the workspace should use this configuration.
+      "default": {
+        "authoring": [
+          "@organization/authoring-metadata@0.1.0",
+          "@team/authoring-metadata@0.1.0"
+        ],
+        "catalog": ["@example/frontend-catalog@workspace:"],
+      },
+
+      // Applies to all packages in the workspace tagged as a "library"
+      "library": {
+        "scripts": ["@example/library-scripts@workspace:"]
+      },
+
+      // Other packages may be tagged as an "application". For this example,
+      // applications have a different set of scripts.
+      "application": {
+        "scripts": ["@example/application-scripts@workspace:"]
+      }
+
+    },
+  }
+}
+```
+
+A special `workspaceConfigs` key can be specified to determine which workspace template configs apply to a given package.
+
+```json5
+// packages/foo/package.json
+{
+  "name": "@example/foo",
+  "pnpm": {
+    "templates": {
+      "workspaceConfigs": ["default", "library"]
+    }
+  }
+}
+```
+
+The example above uses the `default` tag. There is no special treatment for this tag name; it is not applied to all workspace packages implicitly. From a design standpoint, all `package.json` files should specify `pnpm.templates` to communicate to pnpm and other tooling that the file alone is not enough to render its contents.
+
+Despite that, it's likely users will want to enforce that a template is applied to all packages in some manner. An optional `pnpm template check` command will be available to assert that all packages in the workspace configure `pnpm.templates` in a desired manner.
+
 ## Rationale and Alternatives
 
 ### Syncpack

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -1,0 +1,258 @@
+# Templates: Reusable packages to share dependencies and configuration
+
+## Summary
+
+"_Templates_" are packages other package manifests (i.e. `package.json` files) may reference to populate sections of their own definition. This enables data normalization (or deduplication) of local `package.json` files for greater consistency, improved editing ergonomics, and reduced merge conflicts.
+
+## Motivation
+
+Large monorepos often contain many `package.json` files that repeat information. Across these different package manifests, the same metadata fields (e.g. `author`, `repository`, `license`) or dependency versions (e.g. `react`, `jest`) may be declared. When a field or dependency declaration for one package in a monorepo deviates from the others, this can be unintentional and adversely affect the behavior of the project.
+
+### Dependencies
+
+For dependencies specifically, inconsistent versions of the same dependency within a monorepo cause different flavors of problems:
+
+- In projects that bundle dependencies, multiple versions inflate the size of the final result deployed to users.
+- Differing versions result in multiple copies that may not interact well at runtime, especially if features like [`Symbol()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) are used. For example, [React hooks will error if a component is rendered with a different copy of React in the same app](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react).
+- For TypeScript, multiple copies of the same `@types` package causes compile errors from mismatching definitions. The compiler diagnostic for this is usually: *"argument of type `Foo` is not assignable to parameter of type `Foo`"*. For developers that have seen this before, they may realize this diagnostic is due to a dependency version mismatch. For developers new to TypeScript, *"`Foo` is not assignable to `Foo`"* is very confusing.
+
+While there are situations differing versions are intentional, this is more often accidental. Multiple differing versions arise from not reviewing `pnpm-lock.yaml` file changes or not searching for existing dependency specifiers before adding a new one. The later is typically unwritten convention in most monorepos.
+
+### Authoring Fields
+
+Fields such as `author`, `license`, and `repository` are typically expected to be the same across all packages in a monorepo. It would be easier to set this in a singular source of truth rather than every package.
+
+## Detailed Explanation
+
+A "*Template*" is defined as a normal `package.json` file with the `pnpm.template` field set.
+
+```json5
+{
+  "name": "@example/react-template",
+  "pnpm": {
+    "template": true,
+  },
+  "version": "0.1.0",
+  "author": "Example Team <team@team.example>",
+  "license": "MIT",
+  "scripts": {
+    "compile": "tsc"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+  }
+}
+```
+
+Templates must opt into being a template by defining `pnpm.template`. This is a safety mechanism to:
+
+1. Intentionally prevent existing packages from being referred to for that purpose. Templates have different obligations and usage than standard packages that authors of templates should be aware of.
+2. Allow checks to be performed on the template before publishing and during consumption. Not all `package.json` fields may be valid on a template.
+
+A package can reference the template to populate different portions of its definition. The specific feature is determined by `pnpm.templates`: `extends`, `toolkit`, and `catalog`.
+
+### Extends
+
+Using the `pnpm.templates.extends` mechanism, `package.json` fields from templates are copied with small exceptions. The `name`, `dist`, and underscore prefixed fields (e.g. `_npmUser`) are not copied since they're typically specific to the template package itself.
+
+A package referencing the `@example/react-template` above will have the following on-disk and in-memory representations.
+
+**On-Disk**
+
+```json5
+{
+  "name": "@example/react-components",
+  "pnpm": {
+    "templates": {
+      "extends": ["@example/react-template@0.1.0"],
+    }
+  }
+}
+```
+
+**In-Memory and Publish Time**
+
+```json5
+{
+  "name": "@example/react-components",
+  "version": "0.1.0",
+  "author": "Example Team <team@team.example>",
+  "license": "MIT",
+  "scripts": {
+    "compile": "tsc"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+  }
+}
+```
+
+Note that non-standard `package.json` fields such as `eslintConfig` will also be copied. Although these fields have no meaning to package managers, they will appear in the published manifest.
+
+### Toolkit
+
+The `pnpm.templates.toolkit` field copies the `dependencies` block of the template and spreads it into the `devDependencies` of the referencing package.
+
+**On-Disk**
+
+```json5
+{
+  "name": "@example/react-components",
+  "pnpm": {
+    "templates": {
+      "toolkit": ["@example/react-template@0.1.0"],
+    }
+  },
+  "devDependencies": {
+    "jest": "^29.4.3"
+  }
+}
+```
+
+**In-Memory and Publish Time**
+
+```json5
+{
+  "name": "@example/react-components",
+  "dependencies": {
+    "redux": "^4.2.1"
+  },
+  "devDependencies": {
+    "jest": "^29.4.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+  }
+}
+```
+
+This allows package authors to share a reusable set of tools that can be imported or required in the referencing package. Dependencies of dependencies are not normally visible in this manner since pnpm sets up a semi-strict `node_modules` structure by default.
+
+### Catalog
+
+The `pnpm.templates.catalog` feature allows packages to declare a dependency using a version specifier from the referenced template. The `dependencies` block of the template will be available to reference through the `catalog:` version specifier protocol.
+
+**On-Disk**
+
+```json5
+{
+  "name": "@example/react-components",
+  "pnpm": {
+    "templates": {
+      "catalog": ["@example/react-template@0.1.0"],
+    }
+  },
+  "dependencies": {
+    "react": "catalog:"
+  }
+}
+```
+
+**In-Memory and Publish Time**
+
+```json5
+{
+  "name": "@example/react-components",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}
+```
+
+We expect most monorepos to use this feature to keep dependency specifiers consistent between different in-repo packages.
+
+### Combining Templates
+
+Templates may not refer to other templates. Instead of an inheritance hierarchy, a package may refer to multiple templates with later entries in the list taking precedence.
+
+For example, if both `@organization/authoring-metadata` and `@team/authoring-metadata` have an `author` field, the value from `@team/authoring-metadata` will be used.
+
+```json5
+{
+  "name": "@example/simple",
+  "pnpm": {
+    "templates": {
+      "extends": [
+        "@organization/authoring-metadata@0.1.0",
+        "@team/authoring-metadata@0.1.0"
+      ],
+    }
+  }
+}
+```
+
+Avoiding inheritance simplifies implementation and usability in several ways.
+
+- Suppose a new version of pnpm adds `pnpm.templates` config options. In an inheritance model, using these new options on a template would force consumers to a greater minimum version of pnpm.
+- Complex circular resolution during installation is avoided.
+- Template loading is more performant. The requirement to declare all required templates up front enables fetching in a single parallelized step, rather than a waterfall fetch at each level of a theoretical template inheritance hierarchy.
+- It becomes possible to reference multiple templates the package's author does not control with less ambiguity. In an inheritance-based mechanism, multiple inheritance would be necessary for such functionality. However, multiple inheritance can lead to [diamond-shaped problems](https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem) and less clarity as to what the final value of the field should be.
+
+A few of the problems above can be mitigated by rendering the template package itself before publishing, but this introduces other problems. Toolkit templates install dependencies in the referencing package as `devDependencies`, which isn't desirable in other templates.
+
+The existing design is inspired from the concept of "traits" in some programming languages, which provide reusability without inheritance.
+
+### Specifiers
+
+Templates can be specified through:
+
+1. The `name@version` syntax to refer to an external template fetched from a registry.
+2. The `name@workspace:` syntax to refer to a template that's also a workspace package.
+3. The `file:<path>` syntax to refer to an on-disk path.
+
+## Rationale and Alternatives
+
+### Syncpack
+
+[Syncpack](https://github.com/JamieMason/syncpack/) is a great open source tool for keeping `package.json` dependency specifiers in sync on disk.
+
+The proposed solution allows metadata to be defined in a singular file without copying definitions to other files on disk. This is a capability only possible by the package manager reading `package.json` files.
+
+### Comparison to overrides/resolutions
+
+An alternative mechanism for the version catalog is the [`pnpm.overrides` feature](https://pnpm.io/package_json#pnpmoverrides). While mechanically this allows you to set the version of a dependency across all workspace packages, it can be a bit unexpected when if `pnpm.overrides` rewrites a dependency's dependency to an incompatible version silently.
+
+`pnpm.overrides` is ultimately intended for a different purpose. The NPM RFC for a similar feature explicitly states that it should be used as a short-term hack to fix vendor problems.
+
+> Using this feature should be considered a hack in most cases, something that is done temporarily while waiting for a bug to be fixed, or to avoid excessive duplication caused by an overly strict meta-dependency specifier.
+https://github.com/npm/rfcs/blob/main/accepted/0036-overrides.md
+
+The `catalog:` protocol is conversely intended for long-lived usage.
+
+## Implementation
+
+### Fetching
+
+Templates are not installed as standard dependencies and linked into `node_modules`. If a package refers to an external template on an NPM registry, only the metadata will be fetched. The fetch will be performed [without the abbreviated header](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-metadata-format), so the full document is retrieved.
+
+If only a subset of the version catalog is used, the full catalog of dependencies does not need to be installed.
+
+### Lockfile
+
+No explicit changes will be made to the `pnpm-lock.yaml` file. Any `importers` entries referencing a template will have their rendered result saved to the lockfile.
+
+This may be revisited if it affects pnpm's performance when performing up to date checks.
+
+### Portability
+
+Usage of an template package is localized to a monorepo. When a package within the monorepo referencing a template is exported through `pnpm publish` or `pnpm pack`, the resulting `package.json` will be the merged contents of the original `package.json` and its references.
+
+This allows the published `package.json` to be portable and consumed by other package managers.
+
+A command to view the rendered result will be available to assist debugging.
+
+## Prior Art
+
+> This section is optional if there are no actual prior examples in other tools
+
+> Discuss existing examples of this change in other tools, and how they've addressed various concerns discussed above, and what the effect of those decisions has been
+
+- [RFC: First-Class Support for Workspace Consistent Versions](https://github.com/pnpm/rfcs/pull/1)
+- [RFC for parent package.json npm/rfcs#165](https://github.com/npm/rfcs/pull/165)
+- [[RRFC] Accepting version references within dependencies and devDependencies](https://github.com/npm/rfcs/issues/677)
+
+## Unresolved Questions and Bikeshedding
+
+- In prior discussions, this feature was referred to as "_Environments_". The initial draft proposes "_Templates_" to make it more clear that this feature is simply a `package.json` authoring mechanism. Templates/environments are not themselves installed.
+- Should the `version` field be extended by `pnpm.templates.extends`? One on hand, this allows monorepo packages to be single-versioned easily. On the other hand, it can be very surprising when packages are published with the version from a template. Previously forgetting to specify a `version` results in a helpful error.

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -389,8 +389,3 @@ A command to view the rendered result will be available to assist debugging. Whe
 - [RFC: First-Class Support for Workspace Consistent Versions](https://github.com/pnpm/rfcs/pull/1)
 - [RFC for parent package.json npm/rfcs#165](https://github.com/npm/rfcs/pull/165)
 - [[RRFC] Accepting version references within dependencies and devDependencies](https://github.com/npm/rfcs/issues/677)
-
-## Unresolved Questions and Bikeshedding
-
-- In prior discussions, this feature was referred to as "_Environments_". The initial draft proposes "_Templates_" to make it more clear that this feature is simply a `package.json` authoring mechanism. Templates/environments are not themselves installed.
-- It can be tedious to set up the same template configurations for each package in a pnpm workspace. An earlier version of this RFC described a `pnpm.workspaceTemplateConfigs` option can be specified at the root `package.json`. Some version of this is desirable, but the exact solution will be discussed in a separate RFC.

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -22,6 +22,10 @@ While there are situations differing versions are intentional, this is more ofte
 
 Fields such as `author`, `license`, and `repository` are typically expected to be the same across all packages in a monorepo. It would be easier to set this in a singular source of truth rather than every package.
 
+### Workspace Configuration
+
+Workspace settings such as [`pnpm.packageExtensions`](https://pnpm.io/package_json#pnpmpackageextensions) can be shared across different repositories. For example, pnpm includes the [`@yarnpkg/extensions` database](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-extensions/sources/index.ts) builtin. Templates allow users to create their own extensions database.
+
 ## Detailed Explanation
 
 A "*Template*" is defined as a normal `package.json` file with the `pnpm.template` field set.

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -195,7 +195,7 @@ Avoiding inheritance simplifies implementation and usability in several ways.
 
 A few of the problems above can be mitigated by rendering the template package itself before publishing, but this introduces other problems. Toolkit templates install dependencies in the referencing package as `devDependencies`, which isn't desirable in other templates.
 
-The existing design is inspired from the concept of "traits" in some programming languages, which provide reusability without inheritance.
+The existing design is inspired by the concept of ["_composition over inheritance_"](https://en.wikipedia.org/wiki/Composition_over_inheritance), which provides reusability without defining difficult to change relationships between packages.
 
 ### Specifiers
 

--- a/text/0003-templates.md
+++ b/text/0003-templates.md
@@ -284,58 +284,6 @@ Templates can be specified through:
 2. The `name@workspace:` syntax to refer to a template that's also a workspace package.
 3. The `file:<path>` syntax to refer to an on-disk path.
 
-### Shared Workspace Configuration
-
-It can be tedious to set up the same template configurations for each package in a pnpm workspace. The `workspaceTemplateConfigs` option can be specified at the root `package.json` to simplify.
-
-```json5
-// packages.json
-{
-  "pnpm": {
-    "workspaceTemplateConfigs": {
-      // All packages in the workspace should use this configuration.
-      "default": {
-        "authoring": [
-          "@organization/authoring-metadata@0.1.0",
-          "@team/authoring-metadata@0.1.0"
-        ],
-        "catalog": ["@example/frontend-catalog@workspace:"],
-      },
-
-      // Applies to all packages in the workspace tagged as a "library"
-      "library": {
-        "scripts": ["@example/library-scripts@workspace:"]
-      },
-
-      // Other packages may be tagged as an "application". For this example,
-      // applications have a different set of scripts.
-      "application": {
-        "scripts": ["@example/application-scripts@workspace:"]
-      }
-
-    },
-  }
-}
-```
-
-A special `workspaceConfigs` key can be specified to determine which workspace template configs apply to a given package.
-
-```json5
-// packages/foo/package.json
-{
-  "name": "@example/foo",
-  "pnpm": {
-    "templates": {
-      "workspaceConfigs": ["default", "library"]
-    }
-  }
-}
-```
-
-The example above uses the `default` tag. There is no special treatment for this tag name; it is not applied to all workspace packages implicitly. From a design standpoint, all `package.json` files should specify `pnpm.templates` to communicate to pnpm and other tooling that the file alone is not enough to render its contents.
-
-Despite that, it's likely users will want to enforce that a template is applied to all packages in some manner. An optional `pnpm template check` command will be available to assert that all packages in the workspace configure `pnpm.templates` in a desired manner.
-
 ## Rationale and Alternatives
 
 ### Syncpack
@@ -445,3 +393,4 @@ A command to view the rendered result will be available to assist debugging. Whe
 ## Unresolved Questions and Bikeshedding
 
 - In prior discussions, this feature was referred to as "_Environments_". The initial draft proposes "_Templates_" to make it more clear that this feature is simply a `package.json` authoring mechanism. Templates/environments are not themselves installed.
+- It can be tedious to set up the same template configurations for each package in a pnpm workspace. An earlier version of this RFC described a `pnpm.workspaceTemplateConfigs` option can be specified at the root `package.json`. Some version of this is desirable, but the exact solution will be discussed in a separate RFC.


### PR DESCRIPTION
This is a proposal of a templating system for `package.json` files. The RFC does not propose a full templating system where any `package.json` can be referenced to populate any other portions. Templating is more limited specific functionality requested within the community.

[Link to rendered text](https://github.com/pnpm/rfcs/blob/714d1d81d86446412d3dc9a3fdea4144b4d080bb/text/0003-templates.md)

Originally proposed by @zkochan in https://github.com/pnpm/pnpm/issues/2713#issuecomment-1397614116.

Previous discussions:
- https://github.com/pnpm/rfcs/pull/1
- https://github.com/pnpm/pnpm/discussions/5974
- https://github.com/pnpm/pnpm/issues/2713#issuecomment-1397614116

