### PR TITLE
Correct a few mistakes in the catalogs RFC

### DIFF
--- a/text/0001-catalogs.md
+++ b/text/0001-catalogs.md
@@ -389,7 +389,7 @@ The proposed solution allows metadata to be defined in a singular file without c
 
 ### Comparison to overrides/resolutions
 
-An alternative mechanism for the version catalog is the [`pnpm.overrides` feature](https://pnpm.io/package_json#pnpmoverrides). While mechanically this allows you to set the version of a dependency across all workspace packages, it can be a bit unexpected when if `pnpm.overrides` rewrites a dependency's dependency to an incompatible version silently.
+An alternative mechanism for the version catalog is the [`pnpm.overrides` feature](https://pnpm.io/package_json#pnpmoverrides). While mechanically this allows you to set the version of a dependency across all workspace packages, it can be a bit unexpected if `pnpm.overrides` rewrites a dependency's dependency to an incompatible version silently.
 
 `pnpm.overrides` is ultimately intended for a different purpose. The NPM RFC for a similar feature explicitly states that it should be used as a short-term hack to fix vendor problems.
 

--- a/text/0001-catalogs.md
+++ b/text/0001-catalogs.md
@@ -377,7 +377,7 @@ flowchart LR
   end
 ```
 
-This scenario requires human intervention and is outside of the scope of this RFC. It's may be important to note that Yarn allows users to detect these sorts of situations and fail installation through a mechanism called [Constraints](https://yarnpkg.com/features/constraints).
+This scenario currently requires human intervention and is outside of the scope of this RFC. It's possible a future RFC proposal would address this. Such a new proposal would need to propose a configuration syntax for enforcing a single version throughout the full dependency graph.
 
 ## Alternatives
 


### PR DESCRIPTION
## Changes

- I noticed a typo in the "_Comparison to overrides/resolutions_" section.
- Replacing the mention of ["_Yarn constraints_"](https://yarnpkg.com/features/constraints). Although the [Yarn docs on constraints](https://yarnpkg.com/features/constraints) state that it's good for "_Ensuring the same version of dependencies across packages._", there's a note below that it currently doesn't handle "_Transitive dependencies_". I missed this.