### PR TITLE
Add pnpr subdirectory for pnpr-related RFCs

### DIFF
--- a/pnpr/LICENSE.md
+++ b/pnpr/LICENSE.md
@@ -1,0 +1,91 @@
+# PolyForm Shield License 1.0.0
+
+<https://polyformproject.org/licenses/shield/1.0.0>
+
+Required Notice: Copyright 2026 Zoltan Kochan (https://kochan.io)
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing any product that competes with the software or any product the licensor or any of its affiliates provides using the software.
+
+## Competition
+
+Goods and services compete even when they provide functionality through different kinds of interfaces or for different technical platforms.  Applications can compete with services, libraries with plugins, frameworks with development tools, and so on, even if they're written in different programming languages or for different computer architectures.  Goods and services compete even when provided free of charge.  If you market a product as a practical substitute for the software or another product, it definitely competes.
+
+## New Products
+
+If you are using the software to provide a product that does not compete, but the licensor or any of its affiliates brings your product into competition by providing a new version of the software or another product using the software, you may continue using versions of the software available under these terms beforehand to provide your competing product, but not any later versions.
+
+## Discontinued Products
+
+You may begin using the software to compete with a product or service that the licensor or any of its affiliates has stopped providing, unless the licensor includes a plain-text line beginning with `Licensor Line of Business:` with the software that mentions that line of business.  For example:
+
+> Licensor Line of Business: YoyodyneCMS Content Management System (http://example.com/cms)
+
+## Sales of Business
+
+If the licensor or any of its affiliates sells a line of business developing the software or using the software to provide a product, the buyer can also enforce [Noncompete](#noncompete) for that product.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+A **product** can be a good or service, or a combination of them.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all its affiliates.
+
+**Affiliates** means the other organizations than an organization has control over, is under the control of, or is under common control with.
+
+**Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/pnpr/README.md
+++ b/pnpr/README.md
@@ -1,6 +1,6 @@
 # pnpr RFCs
 
-RFCs related to [pnpr](https://github.com/pnpm/pnpm).
+RFCs related to [pnpr](https://github.com/pnpm/pnpm/tree/main/pnpr).
 
 > [!IMPORTANT]
 > Unlike the rest of this repository, the contents of this `pnpr/` directory are

--- a/pnpr/README.md
+++ b/pnpr/README.md
@@ -1,0 +1,14 @@
+# pnpr RFCs
+
+RFCs related to [pnpr](https://github.com/pnpm/pnpm).
+
+> [!IMPORTANT]
+> Unlike the rest of this repository, the contents of this `pnpr/` directory are
+> licensed under the **PolyForm Shield License 1.0.0**, the same license used by
+> pnpr itself. See [LICENSE.md](./LICENSE.md) for the full terms.
+
+## Submitting an RFC
+
+Copy [`text/0000-template.md`](./text/0000-template.md) to
+`text/0000-my-feature.md` (leave the number as `0000` until the RFC is assigned
+one) and open a pull request.

--- a/pnpr/text/0000-template.md
+++ b/pnpr/text/0000-template.md
@@ -1,0 +1,36 @@
+# {{TITLE: a human-readable title for this RFC!}}
+
+## Summary
+
+{{A concise, one-paragraph description of the change.}}
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+## Detailed Explanation
+
+{{Describe the expected changes in detail, }}
+
+## Rationale and Alternatives
+
+{{Discuss 2-3 different alternative solutions that were considered. This is required, even if it seems like a stretch. Then explain why this is the best choice out of available ones.}}
+
+## Implementation
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+{{THIS SECTION IS REQUIRED FOR RATIFICATION -- you can skip it if you don't know the technical details when first submitting the proposal, but it must be there before it's accepted}}
+
+## Prior Art
+
+{{This section is optional if there are no actual prior examples in other tools}}
+
+{{Discuss existing examples of this change in other tools, and how they've addressed various concerns discussed above, and what the effect of those decisions has been}}
+
+## Unresolved Questions and Bikeshedding
+
+{{Write about any arbitrary decisions that need to be made (syntax, colors, formatting, minor UX decisions), and any questions for the proposal that have not been answered.}}
+
+{{THIS SECTION SHOULD BE REMOVED BEFORE RATIFICATION}}
+


### PR DESCRIPTION
Adds a dedicated `pnpr/` subdirectory for RFCs related to [pnpr](https://github.com/pnpm/pnpm).

```
pnpr/
├── LICENSE.md          # PolyForm Shield License 1.0.0 (copied from pnpm/pnpm)
├── README.md           # notes the different license + how to submit
└── text/
    └── 0000-template.md
```

## Why

pnpr is licensed under the **PolyForm Shield License 1.0.0** — a noncompete, source-available license that differs from the rest of this repository. The license is included in the subdirectory and called out in the README so it's clear this directory is governed by different terms.

## Notes

- The root rfcs repo currently has no LICENSE file. If the rest of the repo is meant to be open (MIT/CC), a root LICENSE may be worth adding separately.
- Structured as `pnpr/text/` to mirror the root repo layout; can be flattened to `pnpr/` if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added initial guidance for the `pnpr/` area, including how to submit an RFC and what to include in the proposal.
  * Added a reusable RFC template with standard sections for summary, motivation, implementation, rationale, prior art, and open questions.
  * Included the applicable license text and a clear notice about licensing for the new materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->