### PR TITLE
rfc(pnpr): patch-provider integration

### DIFF
--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -1,0 +1,337 @@
+# Patch-provider integration for pnpr
+
+## Summary
+
+Vendors such as Echo, Seal Security, and Socket ship security-patched builds
+of vulnerable open-source package versions and want to deliver them through
+the registry the organization already uses. pnpr should support this in two
+shapes: a vendor registry as an ordinary **upstream mount** (works today, the
+vendor is the declared origin), and a new **patch overlay mount** that grafts
+a provider's signed patch manifest onto a base mount, substituting per-version
+and deterministically.
+
+Both shapes extend the invariants of the registry-mounts RFC rather than
+weakening them:
+
+> **Provenance is declared, never inferred — now per version.** Every
+> `name@version` resolves to exactly one declared concrete origin, selected by
+> pinned configuration and manifest data, never by request-time existence or
+> availability.
+>
+> **Within one mount, a version's bytes are immutable.** pnpr never serves
+> different bytes under a `name@version` a lockfile may already pin. Choosing
+> patched bytes means choosing either a different declared origin (mount) or a
+> distinct version identifier — never a silent byte swap.
+
+## Motivation
+
+### The registry is the right choke point
+
+Every artifact an organization installs passes through its registry — every
+developer machine, every CI job, every transitive dependency. A remediation
+applied there is applied once, centrally, with no per-repository configuration
+and no gaps for the repo that forgot to install a wrapper CLI or adopt an
+override.
+
+### Patch vendors exist and want registry distribution
+
+A class of products now sells *backported security patches for the exact
+version you already depend on*, so a critical CVE can be remediated without a
+major-version migration:
+
+- **Echo Libraries** runs npm/PyPI/Maven/etc. packages through a hardening
+  pipeline (sandboxing, CVE remediation, signing) and delivers them as an
+  artifact source that mirrors into Nexus, Artifactory, and custom
+  repositories. Echo patches *on the same version number* the application
+  requires.
+- **Seal Security** publishes sealed versions under distinct identifiers —
+  `ejs@2.7.4-sp1` is the first seal-patch of `ejs@2.7.4` — served from Seal's
+  artifact server and adopted via overrides in the consuming project.
+- **Socket** ships Certified Patches as repo-local patch files applied at
+  install time (deliberately not a registry proxy). Its registry product,
+  Socket Firewall, blocks malicious packages but does not substitute patched
+  ones.
+- **Google Assured OSS** rebuilds, patches, and signs popular open-source
+  packages and serves them from Google's own registry endpoint.
+
+These vendors want a way to plug into pnpr, and pnpr deployments want to
+consume them without handing the vendor authority over every package. The
+mount model gives us the vocabulary to do that precisely.
+
+## Detailed Explanation
+
+### Baseline: the vendor as a declared origin
+
+This works with mounts as already specified, with zero new machinery:
+
+```yaml
+mounts:
+  echo:
+    type: upstream
+    url: https://npm.echo.example/org-acme/
+    auth:
+      tokenEnv: ECHO_NPM_TOKEN
+    access: team:acme
+
+  main:
+    type: router
+    routes:
+      - patterns: ['@acme/*']
+        source: acme
+      - patterns: ['**']
+        source: echo
+```
+
+The organization has chosen Echo as its artifact source for public packages.
+Echo's same-version patching model is *coherent* in this shape: the vendor is
+the declared origin, the bytes are the vendor's bytes, the lockfile integrity
+is the vendor's integrity, and that origin is expected to be internally
+consistent about those bytes forever. Nothing is being substituted behind an
+identity another origin defined.
+
+Two consequences are worth stating:
+
+- **Trust is coarse.** The vendor can serve arbitrary bytes for *every*
+  package routed to it, not only the ones it patched. That is the correct
+  contract when the vendor is bought as "our vetted artifact source", and the
+  wrong one when the organization only wants the vendor's patches.
+- **This makes the lockfile registry-identity follow-up urgent.** The same
+  `name@version` now routinely exists with different bytes on `~npmjs` and
+  `~echo`. pnpm's current `name@version` package key cannot represent both in
+  one graph (see the mounts RFC's motivation); a patched-registry deployment
+  will hit that gap on day one when a workspace mixes mounts.
+
+### Patch overlay mounts
+
+For the "only the patches" contract, this RFC adds one new composite mount
+kind. An **overlay** wraps a base concrete mount and grafts in patched
+versions from a patch source, driven by a signed, pinned **patch manifest**:
+
+```yaml
+mounts:
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+
+  echo-patches:
+    type: upstream
+    url: https://npm.echo.example/patched/
+    auth:
+      tokenEnv: ECHO_NPM_TOKEN
+    access: team:acme
+
+  safe-npm:
+    type: overlay
+    base: npmjs
+    patchSource: echo-patches
+    manifest:
+      url: https://npm.echo.example/pnpr-manifest.json
+      publicKeys:
+        - ed25519:AAAA...
+      refreshInterval: 1h
+    policy:
+      requireAdvisoryMatch: true   # a patch must claim to fix a known advisory
+```
+
+The **patch manifest** is a signed document published by the provider mapping
+original versions to patched artifacts:
+
+```jsonc
+{
+  "schema": "pnpr-patch-manifest/1",
+  "entries": {
+    "ejs@2.7.4": {
+      "patchedVersion": "2.7.4-sp1",       // MUST differ from the original
+      "integrity": "sha512-...",            // of the patched tarball
+      "fixes": ["GHSA-...", "CVE-2024-..."],
+      "attestations": ["https://..."]       // provenance, VEX, build info
+    }
+  }
+}
+```
+
+Semantics, in the order the invariants demand:
+
+- **Distinct identity, always.** A manifest entry whose `patchedVersion`
+  equals the original version is rejected at manifest validation. The overlay
+  never swaps bytes under an existing version identifier; the patched artifact
+  is a new version (`2.7.4-sp1`-style) with its own integrity, visible as
+  itself in packuments and lockfiles. Same-version substitution is the
+  vendor-as-origin shape above, never an overlay behavior.
+- **Pinned, not probed.** pnpr fetches and signature-verifies the manifest on
+  its refresh interval and pins a snapshot. Between refreshes, routing is a
+  pure function of config plus the pinned snapshot — a request never asks the
+  provider "do you have a patch for this?" at resolution time. A manifest
+  refresh is a logged, diffable event, like an operator config change.
+- **Per-version, single origin.** The overlay serves the base packument with
+  the manifest's patched versions grafted in as additional versions. A
+  tarball request for a patched version routes to `patchSource`; every other
+  version routes to `base`. Each version has exactly one origin, and the
+  overlay owns no bytes of its own (like a router).
+- **No fall-through, either direction.** If `patchSource` is down or returns
+  not-found for a manifest-listed artifact, that is an error — pnpr does not
+  quietly serve the vulnerable base artifact instead. If the fetched patched
+  tarball fails the manifest integrity, that is an error. The base being down
+  is equally final for base-routed versions.
+- **dist-tags are the base's.** The overlay does not repoint `latest` or any
+  other tag at patched versions. Adoption is explicit (below), not a tag
+  surprise.
+- **Read-only.** Publish, dist-tag, and unpublish through an overlay are
+  rejected with the same "name a hosted mount" error a router gives for
+  upstream-routed writes.
+- **Access composes from the sources.** Consistent with
+  authorize-at-the-concrete-source: `base` and `patchSource` each enforce
+  their own access policy, and the overlay may add its own `access` for the
+  composed surface, but a gated patch source is protected at its own URL
+  regardless of the overlay in front of it.
+
+### How clients adopt patched versions
+
+Grafted versions are deliberately inert until a client asks for them. Three
+adoption paths, from least to most automatic:
+
+1. **Explicit ranges/overrides.** A workspace pins `ejs@2.7.4-sp1` or writes a
+   pnpm override, exactly as Seal customers do today. Works with no client
+   changes.
+2. **Audit enrichment.** pnpr implements the npm audit endpoints
+   (`/-/npm/v1/security/advisories/bulk`) against OSV plus the pinned
+   manifests, and reports, per vulnerable version, the patched version
+   available *on this registry*. `pnpm audit` then shows an actionable fix
+   that does not require a semver upgrade.
+3. **Client resolution preference (pnpm follow-up, out of scope here).** A
+   `preferPatched` resolution mode in pnpm/pacquet: when a range resolves to a
+   version for which the registry advertises a patched variant, resolve the
+   variant instead. Opt-in, recorded in the lockfile as the concrete patched
+   version, so the choice is visible and reproducible. This needs care with
+   semver ordering (below) and belongs in a pnpm RFC.
+
+One sharp edge to standardize: **semver pre-release ordering.**
+`2.7.4-sp1 < 2.7.4`, so ordinary ranges like `^2.7.0` do *not* match patched
+versions — which is precisely why they are safe to graft into packuments (no
+existing range resolution changes), and why adoption paths 1–3 are explicit.
+
+A second sharp edge: **advisory screening of patched versions.** OSV ranges
+like `affected: < 2.7.5` *do* match `2.7.4-sp1` textually. pnpr's advisory
+screening must subtract the manifest's `fixes` list (the provider's VEX claim)
+for that exact artifact — pinned by integrity — so a patched artifact is not
+blocked or flagged by the very advisory it fixes, while remaining subject to
+every other advisory.
+
+## Rationale and Alternatives
+
+### Same-version byte substitution in overlays (Echo's model, overlay-shaped)
+
+Rejected. Serving provider bytes under the base origin's `name@version` means
+the same identity yields different integrity depending on when it was first
+resolved — breaking lockfile verification for existing consumers the moment a
+patch appears, poisoning shared caches with ambiguity about which bytes are
+"the" version, and hiding the substitution from every human reading a
+lockfile. Organizations that want same-version patching have a coherent home
+for it: make the vendor the declared origin (upstream mount), where the vendor
+owns the identity end to end. The overlay's value is precisely that patched
+artifacts are *visible, distinct, opt-in* versions.
+
+### Proxy the provider's packument and merge it live with the base
+
+Rejected. Live-merging two origins' metadata re-creates the
+existence-based-merge model the mounts RFC removed — the composition would
+depend on the provider's availability and current contents at request time.
+The pinned signed manifest keeps composition deterministic between refreshes,
+verifiable, and diffable.
+
+### Leave patching entirely client-side (overrides, Socket-style repo patches)
+
+Not sufficient alone. Repo-local patching (Socket Certified Patches, pnpm
+`patchedDependencies`, overrides) is excellent for application teams and needs
+no infrastructure — but it protects one repository at a time, drifts across
+hundreds of repos, and gives a security organization no central enforcement or
+inventory. Registry-side delivery and repo-side adoption compose; this RFC
+supplies the registry half and the audit enrichment that makes the client half
+discoverable.
+
+### Only support vendor-as-origin, no overlay
+
+Simplest possible scope — and it is the shipped baseline regardless. But it
+forces an all-or-nothing trust decision: to get one vendor's patches, the
+deployment must make that vendor the origin for every routed package. The
+overlay exists so the base origin (say, npmjs) keeps serving everything except
+the specific, signed, advisory-matched artifacts the provider patched.
+
+## Implementation
+
+All changes are in pnpr-server; no pnpm client change is required for the
+baseline or for overlay adoption path 1 (explicit versions/overrides).
+
+1. **Overlay mount kind.** Extend the mount config model with `type: overlay`
+   (`base`, `patchSource`, `manifest`, `policy`); validate at load that base
+   and patchSource are concrete mounts (not routers/overlays), and that no
+   router route uses an overlay as a write target. Manifest
+   fetch/verify/pin machinery with logged refresh diffs; reject entries with
+   `patchedVersion == version` or missing integrity.
+2. **Packument grafting and per-version routing.** Serve base packuments with
+   pinned-manifest versions grafted in; `dist.tarball` stays canonical for the
+   addressed base (mounts RFC rules); tarball requests route patched version
+   ids to `patchSource` and verify manifest integrity, all other versions to
+   `base`. No fall-through on error in either direction.
+3. **Audit endpoint.** Implement/extend the npm advisories bulk endpoint from
+   OSV data, with VEX subtraction for manifest-fixed advisories and "patched
+   version available" enrichment.
+
+Tests should cover, at minimum:
+
+- overlay config validation (non-concrete base/patchSource, same-version
+  manifest entries, unsigned/tampered manifests, write rejection);
+- grafted packuments carrying both origins' versions with canonical tarball
+  URLs, and per-version routing to the correct source;
+- patch-source not-found/unavailable and integrity mismatch surfacing as
+  errors, never serving the vulnerable base artifact;
+- manifest refresh changing routing only at refresh, with the change logged;
+- dist-tags passing through from the base unmodified;
+- access enforced independently at base, patchSource, and overlay;
+- VEX subtraction: patched artifact not flagged by fixed advisories, still
+  flagged by unrelated ones;
+- audit bulk endpoint advertising the patched version for a vulnerable
+  version with a manifest entry.
+
+## Prior Art
+
+- **Seal Security** is the closest model for the overlay: patched versions as
+  distinct `-spN` identifiers served from a dedicated artifact source and
+  adopted explicitly by the consumer. The overlay generalizes this into a
+  provider-neutral signed-manifest protocol.
+- **Echo Libraries** validates the vendor-as-origin shape: a hardened,
+  signed artifact pipeline that mirrors into existing repository managers,
+  patching on the same version number. That same-version model is exactly why
+  it maps to a declared origin rather than an overlay.
+- **Socket Certified Patches** demonstrates the repo-local patching shape;
+  its docs explicitly argue *against* registry-proxy patching for application
+  repos — a fair argument at repo scope that does not hold for
+  organization-wide enforcement, which is pnpr's scope.
+- **Google Assured OSS** — rebuilt, patched, signed packages behind Google's
+  own registry endpoint — is vendor-as-origin at cloud scale.
+- **Snyk's deprecated patch protocol** (per-CVE diff files applied at install
+  time) is a cautionary tale: patch-at-install couples remediation to client
+  tooling and rots; serving real artifacts from a registry does not.
+- **npm audit's bulk advisory endpoint** is the existing client-visible
+  surface this RFC enriches rather than replaces.
+
+## Unresolved Questions and Bikeshedding
+
+- **Manifest schema and vendor buy-in.** No vendor-neutral patch-manifest
+  standard exists. Do we define `pnpr-patch-manifest/1` and ask vendors to
+  emit it, ship per-vendor adapter code, or both? What signature scheme
+  (raw ed25519, DSSE envelopes, sigstore)?
+- **Patched version identifiers.** Adopt the provider's identifier verbatim
+  (`-sp1`, `-echo.1`) or normalize to a pnpr-defined suffix? Pre-release
+  suffixes have the right semver ordering properties but interact with
+  tooling that treats any pre-release as unstable. npm rejects build
+  metadata (`+meta`) on publish, so that alternative is likely closed —
+  verify.
+- **`preferPatched` client resolution** and `pnpm audit --fix` writing
+  overrides to patched versions belong in a pnpm-side RFC; what does pnpr
+  need to expose (beyond audit enrichment) to make those trivial?
+- **Interaction with package screening.** A separate RFC proposes a screening
+  pipeline whose block responses could advertise "a patched version of this
+  artifact is available" when an overlay manifest knows one. That integration
+  is optional in both directions; neither RFC depends on the other.

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -6,22 +6,29 @@ Vendors such as Echo, Seal Security, and Socket ship security-patched builds
 of vulnerable open-source package versions and want to deliver them through
 the registry the organization already uses. pnpr should support this in two
 shapes: a vendor registry as an ordinary **upstream mount** (works today, the
-vendor is the declared origin), and a new **patch overlay mount** that grafts
-a provider's signed patch manifest onto a base mount, substituting per-version
-and deterministically.
+vendor is the declared origin), and a **patch scope** — the provider publishes
+patched artifacts under its own package namespace (`@echo-patch/ejs@2.7.4`),
+served through ordinary mounts and routes, and consumers adopt them via
+**package alias overrides** (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`). A
+signed, pinned **patch manifest** ties the two names together, driving audit
+enrichment and advisory mapping.
+
+Notably, this requires **no new mount kind**. Both shapes are expressible with
+hosted/upstream/router mounts as already specified; what this RFC adds is the
+manifest protocol and the audit/advisory machinery around it.
 
 Both shapes extend the invariants of the registry-mounts RFC rather than
 weakening them:
 
-> **Provenance is declared, never inferred — now per version.** Every
-> `name@version` resolves to exactly one declared concrete origin, selected by
-> pinned configuration and manifest data, never by request-time existence or
-> availability.
+> **Provenance is declared, never inferred.** Every `name@version` resolves to
+> exactly one declared concrete origin. A patched artifact is a *different
+> name* from a *declared provider namespace* — never a request-time
+> substitution behind the original name.
 >
-> **Within one mount, a version's bytes are immutable.** pnpr never serves
-> different bytes under a `name@version` a lockfile may already pin. Choosing
-> patched bytes means choosing either a different declared origin (mount) or a
-> distinct version identifier — never a silent byte swap.
+> **An identity's bytes are immutable.** pnpr never serves different bytes
+> under a `name@version` a lockfile may already pin. Choosing patched bytes
+> means choosing either a different declared origin (mount) or a distinct
+> package identity — never a silent byte swap.
 
 ## Motivation
 
@@ -30,8 +37,9 @@ weakening them:
 Every artifact an organization installs passes through its registry — every
 developer machine, every CI job, every transitive dependency. A remediation
 applied there is applied once, centrally, with no per-repository configuration
-and no gaps for the repo that forgot to install a wrapper CLI or adopt an
-override.
+and no gaps for the repo that forgot to install a wrapper CLI. The registry is
+also the only place that can *tell* every consumer, through the audit
+endpoint, that a patched artifact exists for the exact version they depend on.
 
 ### Patch vendors exist and want registry distribution
 
@@ -87,7 +95,9 @@ Echo's same-version patching model is *coherent* in this shape: the vendor is
 the declared origin, the bytes are the vendor's bytes, the lockfile integrity
 is the vendor's integrity, and that origin is expected to be internally
 consistent about those bytes forever. Nothing is being substituted behind an
-identity another origin defined.
+identity another origin defined. Seal's model fits the same shape: Seal's
+artifact server serves the `ejs` packument with its `-spN` versions included,
+and Seal is simply the declared origin for it.
 
 Two consequences are worth stating:
 
@@ -101,11 +111,20 @@ Two consequences are worth stating:
   one graph (see the mounts RFC's motivation); a patched-registry deployment
   will hit that gap on day one when a workspace mixes mounts.
 
-### Patch overlay mounts
+### Patch scopes: patched artifacts under the provider's namespace
 
-For the "only the patches" contract, this RFC adds one new composite mount
-kind. An **overlay** wraps a base concrete mount and grafts in patched
-versions from a patch source, driven by a signed, pinned **patch manifest**:
+For the "only the patches" contract, the provider publishes each patched
+artifact as its own package under a provider-owned scope, keeping the
+**original version number**:
+
+```text
+ejs@2.7.4                    # the vulnerable original, on npmjs
+@echo-patch/ejs@2.7.4        # Echo's patched build of exactly that version
+```
+
+The patched package's identity is distinct by *name*, so nothing about the
+original — its packument, versions, dist-tags, or bytes — is touched. pnpr
+serves the patch scope through completely ordinary configuration:
 
 ```yaml
 mounts:
@@ -121,10 +140,18 @@ mounts:
       tokenEnv: ECHO_NPM_TOKEN
     access: team:acme
 
-  safe-npm:
-    type: overlay
-    base: npmjs
-    patchSource: echo-patches
+  main:
+    type: router
+    routes:
+      - patterns: ['@echo-patch/*']
+        source: echo-patches
+      - patterns: ['**']
+        source: npmjs
+
+patchProviders:
+  echo:
+    scope: '@echo-patch'
+    source: echo-patches
     manifest:
       url: https://npm.echo.example/pnpr-manifest.json
       publicKeys:
@@ -134,15 +161,23 @@ mounts:
       requireAdvisoryMatch: true   # a patch must claim to fix a known advisory
 ```
 
-The **patch manifest** is a signed document published by the provider mapping
-original versions to patched artifacts:
+No new mount kind, no synthesized packuments, no fall-through anywhere: the
+patch scope is just packages, routed by the existing router rules, cached in
+the existing per-mount namespaces, gated by the existing access policies. The
+new configuration surface is `patchProviders:`, which registers the
+**manifest** that ties the two namespaces together.
+
+### The patch manifest
+
+The manifest is a signed document published by the provider mapping original
+package versions to their patched counterparts:
 
 ```jsonc
 {
   "schema": "pnpr-patch-manifest/1",
   "entries": {
     "ejs@2.7.4": {
-      "patchedVersion": "2.7.4-sp1",       // MUST differ from the original
+      "patched": "@echo-patch/ejs@2.7.4",
       "integrity": "sha512-...",            // of the patched tarball
       "fixes": ["GHSA-...", "CVE-2024-..."],
       "attestations": ["https://..."]       // provenance, VEX, build info
@@ -151,94 +186,153 @@ original versions to patched artifacts:
 }
 ```
 
-Semantics, in the order the invariants demand:
-
-- **Distinct identity, always.** A manifest entry whose `patchedVersion`
-  equals the original version is rejected at manifest validation. The overlay
-  never swaps bytes under an existing version identifier; the patched artifact
-  is a new version (`2.7.4-sp1`-style) with its own integrity, visible as
-  itself in packuments and lockfiles. Same-version substitution is the
-  vendor-as-origin shape above, never an overlay behavior.
 - **Pinned, not probed.** pnpr fetches and signature-verifies the manifest on
-  its refresh interval and pins a snapshot. Between refreshes, routing is a
-  pure function of config plus the pinned snapshot — a request never asks the
-  provider "do you have a patch for this?" at resolution time. A manifest
-  refresh is a logged, diffable event, like an operator config change.
-- **Per-version, single origin.** The overlay serves the base packument with
-  the manifest's patched versions grafted in as additional versions. A
-  tarball request for a patched version routes to `patchSource`; every other
-  version routes to `base`. Each version has exactly one origin, and the
-  overlay owns no bytes of its own (like a router).
-- **No fall-through, either direction.** If `patchSource` is down or returns
-  not-found for a manifest-listed artifact, that is an error — pnpr does not
-  quietly serve the vulnerable base artifact instead. If the fetched patched
-  tarball fails the manifest integrity, that is an error. The base being down
-  is equally final for base-routed versions.
-- **dist-tags are the base's.** The overlay does not repoint `latest` or any
-  other tag at patched versions. Adoption is explicit (below), not a tag
-  surprise.
-- **Read-only.** Publish, dist-tag, and unpublish through an overlay are
-  rejected with the same "name a hosted mount" error a router gives for
-  upstream-routed writes.
-- **Access composes from the sources.** Consistent with
-  authorize-at-the-concrete-source: `base` and `patchSource` each enforce
-  their own access policy, and the overlay may add its own `access` for the
-  composed surface, but a gated patch source is protected at its own URL
-  regardless of the overlay in front of it.
+  its refresh interval and pins a snapshot. Everything derived from it (audit
+  enrichment, advisory mapping) is a pure function of config plus the pinned
+  snapshot. A manifest refresh is a logged, diffable event, like an operator
+  config change.
+- **Scope-bound.** Every `patched` entry must name a package inside the
+  provider's declared scope; an entry pointing anywhere else is rejected at
+  validation. A provider can describe only its own namespace.
+- **Integrity-pinned.** The manifest's integrity for the patched artifact must
+  match what the patch source serves; a mismatch is an error, never a
+  fall-through to the vulnerable original.
+- **Patch re-issues stay inside the namespace.** If a patch itself needs a
+  second revision (a new CVE lands on the same base version), the provider
+  publishes `@echo-patch/ejs@2.7.4-sp2` and updates the manifest entry.
+  Suffix ordering quirks are harmless inside a dedicated patch namespace,
+  because adoption is always an exact pin produced from the manifest — no
+  range resolution against upstream expectations ever happens there.
 
 ### How clients adopt patched versions
 
-Grafted versions are deliberately inert until a client asks for them. Three
-adoption paths, from least to most automatic:
+Adoption is a **package alias override** in the consuming workspace — the
+mechanism pnpm already has for substituting one package for another:
 
-1. **Explicit ranges/overrides.** A workspace pins `ejs@2.7.4-sp1` or writes a
-   pnpm override, exactly as Seal customers do today. Works with no client
-   changes.
+```jsonc
+{
+  "pnpm": {
+    "overrides": {
+      "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"
+    }
+  }
+}
+```
+
+Three adoption paths, from least to most automatic:
+
+1. **Hand-written overrides**, as above. Works today with no pnpr or pnpm
+   changes; the alias installs the patched bytes at every point in the graph
+   where `ejs@2.7.4` appeared, including transitive positions.
 2. **Audit enrichment.** pnpr implements the npm audit endpoints
    (`/-/npm/v1/security/advisories/bulk`) against OSV plus the pinned
-   manifests, and reports, per vulnerable version, the patched version
-   available *on this registry*. `pnpm audit` then shows an actionable fix
-   that does not require a semver upgrade.
-3. **Client resolution preference (pnpm follow-up, out of scope here).** A
-   `preferPatched` resolution mode in pnpm/pacquet: when a range resolves to a
-   version for which the registry advertises a patched variant, resolve the
-   variant instead. Opt-in, recorded in the lockfile as the concrete patched
-   version, so the choice is visible and reproducible. This needs care with
-   semver ordering (below) and belongs in a pnpm RFC.
+   manifests, and reports, per vulnerable version, the exact override spec
+   available *on this registry*. The stock response format has no field for
+   "an aliased fix exists", so pnpr adds a namespaced extension field to each
+   advisory entry carrying the suggested override; clients that do not know
+   the field ignore it.
+3. **`pnpm audit --fix` (pnpm follow-up, out of scope here).** pnpm reads the
+   enriched audit response and writes the alias overrides mechanically. This
+   is deliberately a *write-my-config* flow, not a resolution-time behavior:
+   the override is visible in the workspace manifest and lockfile, reviewable
+   in the PR that introduces it, and removable when the team upgrades away
+   from the vulnerable base version.
 
-One sharp edge to standardize: **semver pre-release ordering.**
-`2.7.4-sp1 < 2.7.4`, so ordinary ranges like `^2.7.0` do *not* match patched
-versions — which is precisely why they are safe to graft into packuments (no
-existing range resolution changes), and why adoption paths 1–3 are explicit.
+What the alias buys over other encodings of "patched artifact":
 
-A second sharp edge: **advisory screening of patched versions.** OSV ranges
-like `affected: < 2.7.5` *do* match `2.7.4-sp1` textually. pnpr's advisory
-screening must subtract the manifest's `fixes` list (the provider's VEX claim)
-for that exact artifact — pinned by integrity — so a patched artifact is not
-blocked or flagged by the very advisory it fixes, while remaining subject to
-every other advisory.
+- **The original version number is preserved** (`2.7.4`, not `2.7.4-sp1`), so
+  everything keyed on version — semver ranges inside the patched namespace,
+  `require('ejs/package.json').version` probes, version-gated behavior —
+  sees the version the application was tested against. This is the property
+  Echo's product leads with, delivered without same-version byte swapping.
+- **Provenance is legible in every artifact that records the name.** The
+  lockfile, `node_modules`, SBOMs, and audit logs all show `@echo-patch/ejs`
+  — nobody has to know that `-sp1` means "Seal patch" to notice a
+  substitution happened.
+- **No prerelease semantics.** Tools that treat any prerelease as unstable —
+  `npm outdated`, Renovate/Dependabot version filtering, semver-range
+  tooling — never see a prerelease identifier on the adoption path.
+
+### Advisory screening of patched artifacts
+
+Aliasing moves the advisory problem rather than removing it, and the manifest
+is what solves it. OSV advisories are keyed by the *original* package name:
+
+- `@echo-patch/ejs@2.7.4` matches no `ejs` advisory textually — including
+  future ones. Without correction this is a **blind spot**: a brand-new CVE
+  against `ejs@2.7.4` would flag the vulnerable original but silently miss
+  the patched copy of it, which is equally affected unless the provider says
+  otherwise.
+- pnpr therefore screens every patch-scope artifact **as its upstream
+  identity**, resolved through the pinned manifest: `@echo-patch/ejs@2.7.4`
+  is evaluated against `ejs@2.7.4`'s advisories, *minus* the manifest's
+  `fixes` list (the provider's VEX claim) for that exact integrity-pinned
+  artifact. Fixed advisories are subtracted; everything else — including
+  advisories published after the patch — applies normally.
+- The same mapping feeds the audit endpoint, so a workspace that adopted a
+  patched artifact still hears about new advisories against its base version.
 
 ## Rationale and Alternatives
 
-### Same-version byte substitution in overlays (Echo's model, overlay-shaped)
+### Prerelease-version grafting behind the original name
 
-Rejected. Serving provider bytes under the base origin's `name@version` means
-the same identity yields different integrity depending on when it was first
-resolved — breaking lockfile verification for existing consumers the moment a
-patch appears, poisoning shared caches with ambiguity about which bytes are
-"the" version, and hiding the substitution from every human reading a
-lockfile. Organizations that want same-version patching have a coherent home
-for it: make the vendor the declared origin (upstream mount), where the vendor
-owns the identity end to end. The overlay's value is precisely that patched
-artifacts are *visible, distinct, opt-in* versions.
+The main alternative — and this RFC's own earlier draft — is an **overlay
+mount** that serves the base origin's packument with provider-patched versions
+grafted in as distinct prerelease-style versions (`ejs@2.7.4-sp1`), routing
+those versions to the patch source and everything else to the base.
 
-### Proxy the provider's packument and merge it live with the base
+Its advantage is discoverability in one namespace: the patched versions appear
+in `npm view ejs versions`, and adoption is a version-only override with no
+name change. It is rejected as the primary mechanism because:
 
-Rejected. Live-merging two origins' metadata re-creates the
-existence-based-merge model the mounts RFC removed — the composition would
-depend on the provider's availability and current contents at request time.
-The pinned signed manifest keeps composition deterministic between refreshes,
-verifiable, and diffable.
+- **It synthesizes metadata.** The overlay serves a packument that no single
+  origin published — base metadata with foreign versions spliced in. That is
+  declared and deterministic, but it is still the one place in the design
+  where pnpr manufactures a document blending two origins, and the alias
+  model needs nothing like it.
+- **It requires a new composite mount kind**, with its own validation, routing,
+  write-rejection, and access-composition rules. The alias model is ordinary
+  packages through ordinary mounts.
+- **Prerelease identifiers fight the ecosystem.** `2.7.4-sp1 < 2.7.4` in
+  semver — useful for keeping ranges from matching accidentally, but the same
+  property makes every prerelease-aware tool treat the patched artifact as
+  unstable, and OSV ranges like `< 2.7.5` match it textually, requiring VEX
+  subtraction just to serve it.
+- **The version number lies about itself either way.** `2.7.4-sp1` is neither
+  the version the application pinned nor a version upstream ever published.
+  `@echo-patch/ejs@2.7.4` keeps the real version and moves the difference
+  into the name, where provenance belongs.
+
+Providers that already ship same-name prerelease patches (Seal's `-spN`) are
+still fully served: their artifact server is a vendor-as-origin upstream
+mount, unchanged.
+
+### Same-version byte substitution behind the original name
+
+Rejected in any pnpr-mediated form. Serving provider bytes under the base
+origin's `name@version` means the same identity yields different integrity
+depending on when it was first resolved — breaking lockfile verification for
+existing consumers the moment a patch appears, poisoning shared caches with
+ambiguity about which bytes are "the" version, and hiding the substitution
+from every human reading a lockfile. Organizations that want same-version
+patching have a coherent home for it: make the vendor the declared origin
+(upstream mount), where the vendor owns the identity end to end.
+
+### Named-registry aliases: same name, same version, different registry
+
+The most elegant encoding is arguably pnpm's named registries: override
+`ejs@2.7.4` with `echo:ejs@2.7.4` — identical name and version, provenance
+carried entirely by the registry component of the package identity, exactly
+the model vlt's DepID uses and the mounts RFC already endorses for lockfiles.
+
+Deferred, not rejected: it depends on the lockfile registry-identity
+follow-up (today pnpm's `name@version` package key cannot hold `ejs@2.7.4`
+from two registries in one graph — precisely this situation), and it is
+expressible only by clients with named-registry support, where the scoped
+alias works in any npm-compatible client. When the lockfile work lands, the
+manifest's `patched` field can name a registry-qualified spec as an
+alternative encoding, and the adoption machinery above carries over
+unchanged.
 
 ### Leave patching entirely client-side (overrides, Socket-style repo patches)
 
@@ -246,64 +340,76 @@ Not sufficient alone. Repo-local patching (Socket Certified Patches, pnpm
 `patchedDependencies`, overrides) is excellent for application teams and needs
 no infrastructure — but it protects one repository at a time, drifts across
 hundreds of repos, and gives a security organization no central enforcement or
-inventory. Registry-side delivery and repo-side adoption compose; this RFC
-supplies the registry half and the audit enrichment that makes the client half
-discoverable.
+inventory. Note that the alias model *ends* in a client-side override too —
+the registry's role is serving the patched namespace, vouching for the
+manifest, and making patches discoverable through audit; the client's role is
+adopting them visibly.
 
-### Only support vendor-as-origin, no overlay
+### Only support vendor-as-origin, no patch scopes
 
 Simplest possible scope — and it is the shipped baseline regardless. But it
 forces an all-or-nothing trust decision: to get one vendor's patches, the
 deployment must make that vendor the origin for every routed package. The
-overlay exists so the base origin (say, npmjs) keeps serving everything except
-the specific, signed, advisory-matched artifacts the provider patched.
+patch scope exists so the base origin (say, npmjs) keeps serving everything
+except the specific, signed, advisory-matched artifacts the provider patched.
 
 ## Implementation
 
-All changes are in pnpr-server; no pnpm client change is required for the
-baseline or for overlay adoption path 1 (explicit versions/overrides).
+All registry-side changes are in pnpr-server, and none of them touch the mount
+graph, routing, or serving paths:
 
-1. **Overlay mount kind.** Extend the mount config model with `type: overlay`
-   (`base`, `patchSource`, `manifest`, `policy`); validate at load that base
-   and patchSource are concrete mounts (not routers/overlays), and that no
-   router route uses an overlay as a write target. Manifest
-   fetch/verify/pin machinery with logged refresh diffs; reject entries with
-   `patchedVersion == version` or missing integrity.
-2. **Packument grafting and per-version routing.** Serve base packuments with
-   pinned-manifest versions grafted in; `dist.tarball` stays canonical for the
-   addressed base (mounts RFC rules); tarball requests route patched version
-   ids to `patchSource` and verify manifest integrity, all other versions to
-   `base`. No fall-through on error in either direction.
-3. **Audit endpoint.** Implement/extend the npm advisories bulk endpoint from
-   OSV data, with VEX subtraction for manifest-fixed advisories and "patched
-   version available" enrichment.
+1. **`patchProviders:` config and manifest machinery.** Parse/validate the
+   provider block (scope, source mount, manifest URL, keys, policy);
+   fetch/verify/pin manifests on the refresh interval with logged diffs;
+   reject entries outside the provider's scope, without integrity, or (under
+   `requireAdvisoryMatch`) without a known advisory in `fixes`.
+2. **Advisory identity mapping.** Screen patch-scope artifacts as their
+   manifest-mapped upstream identity, minus the `fixes` list for the pinned
+   integrity; apply the same mapping wherever advisories are evaluated
+   (screening policy, audit responses).
+3. **Audit endpoint enrichment.** Implement/extend the npm advisories bulk
+   endpoint from OSV data, adding the namespaced extension field with the
+   suggested override spec when a pinned manifest covers a vulnerable
+   version.
+
+Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
+overrides from the enriched audit response.
 
 Tests should cover, at minimum:
 
-- overlay config validation (non-concrete base/patchSource, same-version
-  manifest entries, unsigned/tampered manifests, write rejection);
-- grafted packuments carrying both origins' versions with canonical tarball
-  URLs, and per-version routing to the correct source;
-- patch-source not-found/unavailable and integrity mismatch surfacing as
-  errors, never serving the vulnerable base artifact;
-- manifest refresh changing routing only at refresh, with the change logged;
-- dist-tags passing through from the base unmodified;
-- access enforced independently at base, patchSource, and overlay;
-- VEX subtraction: patched artifact not flagged by fixed advisories, still
-  flagged by unrelated ones;
-- audit bulk endpoint advertising the patched version for a vulnerable
-  version with a manifest entry.
+- provider config validation (unknown source mount, scope collisions between
+  providers, unsigned/tampered manifests, out-of-scope entries, missing
+  integrity, `requireAdvisoryMatch` violations);
+- manifest refresh changing derived data only at refresh, with the change
+  logged;
+- patch-scope packages serving through ordinary routing with the source
+  mount's access policy enforced;
+- integrity mismatch between manifest and patch source surfacing as an error;
+- advisory mapping: a patched artifact not flagged by fixed advisories,
+  flagged by unrelated ones, and flagged by advisories published *after* the
+  patch against the same base version;
+- audit bulk endpoint carrying the override-spec extension for a vulnerable
+  version with a manifest entry, and omitting it otherwise;
+- vendor-as-origin deployments (Seal-style `-spN` packuments) proxying
+  unchanged through an upstream mount.
 
 ## Prior Art
 
-- **Seal Security** is the closest model for the overlay: patched versions as
-  distinct `-spN` identifiers served from a dedicated artifact source and
-  adopted explicitly by the consumer. The overlay generalizes this into a
-  provider-neutral signed-manifest protocol.
-- **Echo Libraries** validates the vendor-as-origin shape: a hardened,
-  signed artifact pipeline that mirrors into existing repository managers,
-  patching on the same version number. That same-version model is exactly why
-  it maps to a declared origin rather than an overlay.
+- **Seal Security** proves the adopt-via-override flow: patched versions
+  under distinct identifiers, adopted by explicit overrides in the consuming
+  project. This RFC keeps the override flow and moves the distinct identifier
+  from the version to the name.
+- **Echo Libraries** validates the vendor-as-origin shape and the
+  same-version requirement: a hardened, signed artifact pipeline that mirrors
+  into existing repository managers, patching on the version the application
+  already requires. The patch scope delivers that property without byte
+  swapping.
+- **npm package aliases** (`npm:name@version`) are the established substitution
+  mechanism this design rides on; pnpm supports aliases both as dependencies
+  and as override targets, which is what makes adoption a config edit rather
+  than a client feature.
+- **vlt's DepID** (registry as a component of package identity) is the prior
+  art for the deferred named-registry encoding.
 - **Socket Certified Patches** demonstrates the repo-local patching shape;
   its docs explicitly argue *against* registry-proxy patching for application
   repos — a fair argument at repo scope that does not hold for
@@ -322,16 +428,25 @@ Tests should cover, at minimum:
   standard exists. Do we define `pnpr-patch-manifest/1` and ask vendors to
   emit it, ship per-vendor adapter code, or both? What signature scheme
   (raw ed25519, DSSE envelopes, sigstore)?
-- **Patched version identifiers.** Adopt the provider's identifier verbatim
-  (`-sp1`, `-echo.1`) or normalize to a pnpr-defined suffix? Pre-release
-  suffixes have the right semver ordering properties but interact with
-  tooling that treats any pre-release as unstable. npm rejects build
-  metadata (`+meta`) on publish, so that alternative is likely closed —
-  verify.
-- **`preferPatched` client resolution** and `pnpm audit --fix` writing
-  overrides to patched versions belong in a pnpm-side RFC; what does pnpr
-  need to expose (beyond audit enrichment) to make those trivial?
-- **Interaction with package screening.** A separate RFC proposes a screening
-  pipeline whose block responses could advertise "a patched version of this
-  artifact is available" when an overlay manifest knows one. That integration
-  is optional in both directions; neither RFC depends on the other.
+- **Patch-scope naming.** Is the scope purely provider-chosen
+  (`@echo-patch`, `@seal`), or should pnpr recommend a convention? Scope
+  squatting on the public registry is a consideration when the patch source
+  is also reachable as a plain npm registry.
+- **Alias-override support matrix.** pnpm supports `npm:` aliases in
+  overrides; verify the exact behavior in npm's `overrides` and yarn's
+  `resolutions` so the audit-suggested spec works (or degrades clearly)
+  across clients.
+- **Audit extension field shape.** The exact name and structure of the
+  namespaced field carrying the suggested override in the bulk-advisories
+  response, and whether `pnpm audit` should render it without the `--fix`
+  follow-up.
+- **SBOM/upstream identity mapping.** License and SBOM tooling will record
+  `@echo-patch/ejs`; should pnpr expose the manifest mapping (patched name →
+  upstream identity) as an endpoint so downstream tooling can resolve it, or
+  is the provider's attestation the right carrier?
+- **Named-registry encoding timing.** Revisit `echo:ejs@2.7.4`-style
+  overrides once the pnpm lockfile registry-identity follow-up lands.
+- **Interaction with package screening.** The separate screening RFC's block
+  responses could advertise "a patched artifact is available" via the same
+  manifest data. That integration is optional in both directions; neither RFC
+  depends on the other.

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -748,6 +748,39 @@ Tests should cover, at minimum:
   tooling and rots; serving real artifacts from a registry does not.
 - **npm audit's bulk advisory endpoint** is the existing client-visible
   surface this RFC enriches rather than replaces.
+- **Go's `replace` directive with a left-side version**
+  (`replace ejs v2.7.4 => patched v2.7.4`) is the closest living precedent
+  for the exact-version override extension: it applies **only when minimal
+  version selection selects exactly that version**, other versions are
+  untouched, and it is honored only in the main module — the same
+  substitute-the-selected-pick, workspace-holds-authority shape proposed
+  here.
+- **Cargo's `[replace]`** was post-resolution exact-version substitution
+  almost verbatim: keyed by an exact package id, it swapped the *source* of
+  an already-resolved node, and the replacement was required to keep the
+  same name and version — precisely the same-version-different-build
+  contract of a security patch. It was deprecated in favor of `[patch]`
+  because users wanted *version-changing* overrides (unpublished bumps),
+  which `[replace]` could not express — a need this design leaves with
+  pnpm's existing spec-rewriting overrides, keeping the post-pick mechanism
+  for the case where even Cargo's docs note `[patch]` merely "acts just
+  like `[replace]`": identical name and version, different source.
+- **npm's overrides (RFC 0036)** are the cautionary tale for *where* to
+  match. npm's version-keyed overrides do try to match resolved versions
+  ("a match if the named package specifier would be satisfied by the
+  dependency being considered"), but the matching runs during arborist tree
+  construction, when nodes may not have versions yet — a timing entanglement
+  that produced years of bugs, including two consecutive `npm install` runs
+  emitting different lockfiles (broken from 8.3.0, fixed in 11.2.0). The
+  extension proposed here matches at one well-defined point, after the pick.
+  npm's rule that the override *value* also counts as a match (so versions
+  cannot be swapped in cycles) is the analogue of this design's
+  applied-exactly-once rule.
+- **yarn's `resolutions`** (Berry) match the *declared descriptor* — a
+  `foo@^1.0.0` key matches dependents that declared `^1.0.0`, not picks that
+  land in it — confirming that every JS package manager's override surface
+  is declaration-level today, and none can express "the version resolution
+  actually chose" without an extension like the one proposed.
 
 ## Unresolved Questions and Bikeshedding
 

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -13,17 +13,18 @@ manifest** ties the two names together, and a per-mount `patching:` policy
 applies it in one of two modes: **advertise**, where consumers adopt patches
 explicitly via package alias overrides
 (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) surfaced through audit
-enrichment, and **substitute**, where the registry compiles the manifest into
-a ready-made **overrides object** served at a well-known endpoint, which
-patch-aware clients fetch and apply automatically at resolution — so *fresh
-resolutions* receive the patched artifact as an ordinary recorded alias with
-a canonical, host-free lockfile resolution, while already-pinned installs are
-never altered.
+enrichment, and **substitute**, where the registry serves a ready-made
+**patched-versions document** at a well-known endpoint, which patch-aware
+clients fetch and apply **after version selection**: whenever resolution
+picks a version the document covers, the client resolves the provider's
+aliased artifact instead — recorded like an ordinary alias, with a canonical,
+host-free lockfile resolution — while already-pinned installs are never
+altered.
 
 Notably, this requires **no new mount kind** and no changes to how packuments
 or tarballs are served. Both shapes are expressible with
 hosted/upstream/router mounts as already specified; what this RFC adds is the
-manifest protocol, a registry-served overrides document, and the
+manifest protocol, a registry-served patched-versions document, and the
 audit/advisory machinery around it.
 
 Both shapes extend the invariants of the registry-mounts RFC rather than
@@ -236,6 +237,17 @@ another:
 }
 ```
 
+One property of overrides matters here: an override rewrites the **declared
+specs** in `package.json` files, and its selector matches a declared range by
+subset. The exact-version key above therefore covers dependencies declared as
+`2.7.4` (typical for lockstep pins and many transitive declarations) but
+*not* a dependency declared as `^2.7.0` — no selector short of the bare name
+matches that, and a bare-name override
+(`"ejs": "npm:@echo-patch/ejs@2.7.4"`) also *forces* the version for every
+`ejs` in the graph. Both are legitimate hand-written choices — visible,
+reviewable, deliberate — but the range case is handled properly by substitute
+mode (below), which is applied after version selection instead of to specs.
+
 Three adoption paths, from least to most automatic:
 
 1. **Hand-written overrides**, as above. Works today with no pnpr or pnpm
@@ -278,19 +290,20 @@ never run `pnpm audit` never find out. When the deployment's intent is "no
 fresh resolution may pick a version we have a patch for", that is substitute
 mode.
 
-### Substitute mode: a registry-provided overrides object
+### Substitute mode: a registry-provided patched-versions document
 
 Advertise mode's audit enrichment already computes, per vulnerable version,
-the exact override a workspace should adopt. `substitute` mode serves that
+the substitution a workspace should adopt. `substitute` mode serves that
 same result wholesale: the registry compiles the pinned, policy-filtered
-manifests into one **overrides object** — in pnpm's own overrides format —
-at a well-known endpoint on each registry base that enables it:
+manifests into one **patched-versions document** — a flat map from exact
+original versions to alias specs — at a well-known endpoint on each registry
+base that enables it:
 
 ```jsonc
-// GET <registry base>/-/pnpr/overrides
+// GET <registry base>/-/pnpr/patched-versions
 {
-  "schema": "pnpr-overrides/1",
-  "overrides": {
+  "schema": "pnpr-patched-versions/1",
+  "versions": {
     "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4",
     "lodash@4.17.20": "npm:@echo-patch/lodash@4.17.20"
   }
@@ -313,27 +326,34 @@ mounts:
 ```
 
 A patch-aware client (a small pnpm follow-up) fetches the document once per
-resolution run and merges it at the **lowest precedence** — anything the
-workspace declares wins — exactly as if the workspace had written those
-overrides by hand. Everything downstream is pnpm's already-shipped alias
+resolution run and applies it **after version selection** — deliberately
+*not* as a pnpm override. Overrides rewrite declared specs and match them by
+subset, so an exact-version key like `ejs@2.7.4` would never apply to a
+dependency declared as `^2.7.0` — and `^2.7.0` picking `2.7.4` is exactly the
+fresh-resolution case substitute mode exists for. Instead, the client
+resolves every spec exactly as it does today, and when the **picked** version
+appears in the document, it resolves the mapped alias target in its place.
+Version selection is never changed — only which *build* of the selected
+version is installed. Everything downstream is pnpm's already-shipped alias
 machinery, and that is the point:
 
 - **The lockfile stays canonical and host-free.** A fresh resolution of
-  `^2.7.0` picks `2.7.4`, the override redirects it, and the lockfile records
-  the aliased package `@echo-patch/ejs@2.7.4` with a canonical resolution —
-  integrity only, tarball URL recomputed from registry config at install
-  time. Nothing deployment-specific is persisted; portability is exactly that
-  of any aliased dependency.
-- **No pinned install ever changes.** Overrides act only when a resolution is
-  made. An existing lockfile entry is never touched, and a
+  `^2.7.0` picks `2.7.4`, the document redirects that pick, and the lockfile
+  records the aliased package `@echo-patch/ejs@2.7.4` with a canonical
+  resolution — integrity only, tarball URL recomputed from registry config at
+  install time. Nothing deployment-specific is persisted; portability is
+  exactly that of any aliased dependency.
+- **No pinned install ever changes.** Substitution acts only when a
+  resolution is made. An existing lockfile entry is never touched, and a
   `--frozen-lockfile` install neither fetches nor applies the document.
   Substitute at resolution, never at fetch.
 - **Provenance is legible and diffable.** The lockfile shows `ejs` resolving
   to `@echo-patch/ejs@2.7.4`; when a manifest refresh moves a patch to
   `-sp2`, the next non-frozen resolution produces a reviewable lockfile diff.
-- **Opting out is ordinary config.** A workspace that must keep the
-  vulnerable original pins it with its own override, which outranks the
-  registry-provided one — visible and reviewable, like every other override.
+- **Opting out is explicit workspace config.** A workspace that must keep a
+  vulnerable original declares the exclusion in its own config (the pnpm
+  follow-up defines the exact setting — e.g., an ignore list for registry
+  patches), visible and reviewable like an override.
 
 Clients that are not patch-aware never ask for the document and resolve the
 vulnerable original — no worse than today. Per-mount policy can escalate:
@@ -349,9 +369,10 @@ Costs and requirements, stated honestly:
 
 - **Automatic protection reaches only patch-aware clients.** npm and yarn
   users get advertise-mode discovery (and `refuse`, where enabled). pnpr is
-  pnpm-first, and the document is deliberately pnpm's overrides shape so
-  other tools can consume it too — an org can even paste it into a shared
-  config today.
+  pnpm-first, and the document format is deliberately trivial — exact version
+  in, alias spec out — so other tools can consume it, and an org can still
+  mechanically derive blunt bare-name overrides from it for clients that
+  predate the feature.
 - **Provider retention becomes load-bearing.** A lockfile aliasing
   `@echo-patch/ejs@2.7.4` installs only while that artifact remains
   available. Providers must treat their patch namespaces as immutable and
@@ -364,15 +385,15 @@ Costs and requirements, stated honestly:
   intent — but it is one more reason registry identity belongs in package
   identity.
 
-Determinism and conflicts: the served overrides object is a pure function of
-the mount's `patching:` config plus the pinned manifest snapshots — the same
+Determinism and conflicts: the served document is a pure function of the
+mount's `patching:` config plus the pinned manifest snapshots — the same
 determinism contract as router routes. A refresh that changes it is logged
 and diffable, and the document carries a digest/ETag so clients cache it
 cheaply. Within one mount, at most one provider may claim a given original
 `name@version`; two manifests colliding is a config error, not a precedence
 guess. And substitution composes with advertise-mode machinery — the audit
 endpoint still reports the mapping, so a workspace can see which of its
-resolutions came from the registry's overrides and pin them explicitly if it
+resolutions came from the registry's document and pin them explicitly if it
 prefers.
 
 **Document size.** The document grows linearly with the provider's patch
@@ -427,8 +448,8 @@ name change. It is rejected as the primary mechanism because:
 - **It synthesizes metadata.** The overlay serves a packument that no single
   origin published — base metadata with foreign *version entries* spliced
   into the version list. The alias model never modifies a served packument in
-  any mode: the overrides document lives beside the registry surface, not
-  inside another origin's metadata — yet grafting buys neither automatic
+  any mode: the patched-versions document lives beside the registry surface,
+  not inside another origin's metadata — yet grafting buys neither automatic
   protection (last bullet below) nor a cleaner adoption story.
 - **It requires a new composite mount kind**, with its own validation, routing,
   write-rejection, and access-composition rules. The alias model is ordinary
@@ -471,7 +492,7 @@ where the vendor owns the identity end to end.
 ### Serving the substitution inside packuments
 
 Two earlier shapes of substitute mode put the mapping into the served
-packument itself instead of a separate overrides document:
+packument itself instead of a separate document:
 
 - **Rewrite the vulnerable version's `dist`** to the patched artifact's
   tarball URL and integrity. Its appeal is universality — every npm client
@@ -487,10 +508,25 @@ packument itself instead of a separate overrides document:
   origin's metadata on the serving path, and the client must discover
   patches one packument at a time.
 
-The registry-provided overrides object subsumes both: the same information,
-one standard-shaped document beside the registry surface, zero changes to
-packument or tarball serving — and the client-side behavior it enables is
-identical to overrides the workspace could have written itself.
+The registry-provided document subsumes both: the same information, one
+document beside the registry surface, zero changes to packument or tarball
+serving, and one client-side application point after version selection.
+
+### Applying the document as literal pnpm overrides
+
+An earlier draft served the document *in overrides format* for the client to
+merge alongside workspace overrides. Rejected because the semantics do not
+line up. Overrides rewrite **declared specs** before resolution, and a
+selector matches a declared range by subset: `"ejs@2.7.4"` applies to a
+dependency declared as `2.7.4`, but not to `^2.7.0` — whose resolution to
+`2.7.4` is exactly the case that needs protection. Widening the selector
+cannot fix it: no range selector matches `^2.7.0` short of the bare name,
+and a bare-name override (`"ejs": "npm:@echo-patch/ejs@2.7.4"`) *changes
+version selection* — it forces every `ejs` in the graph to the patched
+`2.7.4`, downgrading a `^2.7.0` that would have picked a genuinely fixed
+`2.7.5`. Post-pick substitution has neither problem: the resolver picks
+whatever it would have picked, and only a picked version with a patch is
+swapped for its patched build of the *same* version.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -545,17 +581,17 @@ mount graph, routing, or the packument/tarball serving paths:
    endpoint from OSV data, adding the namespaced extension field with the
    suggested override spec when a pinned manifest covers a vulnerable
    version.
-4. **Per-mount `patching:` policy and the overrides endpoint.** Validate the
-   policy block (known provider, mode, severity gate, `unawareClients`, one
-   substituting provider per original `name@version` per mount); compile the
-   pinned, policy-filtered manifests into the `/-/pnpr/overrides` document
-   with a digest/ETag, recompiled only on manifest refresh or config reload;
-   implement `unawareClients: refuse` on the tarball route with the `403`
-   reason body.
+4. **Per-mount `patching:` policy and the patched-versions endpoint.**
+   Validate the policy block (known provider, mode, severity gate,
+   `unawareClients`, one substituting provider per original `name@version`
+   per mount); compile the pinned, policy-filtered manifests into the
+   `/-/pnpr/patched-versions` document with a digest/ETag, recompiled only on
+   manifest refresh or config reload; implement `unawareClients: refuse` on
+   the tarball route with the `403` reason body.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
-overrides from the enriched audit response, and fetch-and-merge of the
-registry-provided overrides document at lowest precedence during resolution.
+overrides from the enriched audit response, and post-pick substitution from
+the registry-provided patched-versions document during resolution.
 
 Tests should cover, at minimum:
 
@@ -572,7 +608,7 @@ Tests should cover, at minimum:
   patch against the same base version;
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
-- the overrides document compiled from pinned manifests, filtered by
+- the patched-versions document compiled from pinned manifests, filtered by
   `minSeverity`, stable between refreshes, and served with a digest/ETag;
 - packuments and tarball responses byte-identical with `patching:` enabled
   and disabled — substitute mode touches neither serving path;
@@ -582,7 +618,7 @@ Tests should cover, at minimum:
   with `403` plus the suggested override, and leaving uncovered artifacts
   untouched;
 - the one-substituting-provider-per-original rule enforced at config load;
-- a manifest refresh changing the overrides document being logged, and
+- a manifest refresh changing the patched-versions document being logged, and
   previously aliased patched artifacts continuing to serve as long as the
   provider retains them;
 - vendor-as-origin deployments (Seal-style `-spN` packuments) proxying
@@ -605,9 +641,10 @@ Tests should cover, at minimum:
   than a client feature.
 - **pnpm's config dependencies** (RFC 0004) already distribute shared
   overrides to many repositories through an installed package; the
-  registry-provided overrides document is the same idea with the registry as
-  the distribution channel, and the two can coexist (an org can compile the
-  document into a config dependency for clients that predate the endpoint).
+  registry-provided patched-versions document is the same idea with the
+  registry as the distribution channel, and the two can coexist (an org can
+  derive overrides from the document into a config dependency for clients
+  that predate the endpoint).
 - **vlt's DepID** (registry as a component of package identity) is the prior
   art for the deferred named-registry encoding.
 - **Socket Certified Patches** demonstrates the repo-local patching shape;
@@ -646,19 +683,22 @@ Tests should cover, at minimum:
   is the provider's attestation the right carrier?
 - **Named-registry encoding timing.** Revisit `echo:ejs@2.7.4`-style
   overrides once the pnpm lockfile registry-identity follow-up lands; the
-  overrides document could then carry registry-qualified specs as an
+  patched-versions document could then carry registry-qualified specs as an
   alternative encoding.
-- **Overrides endpoint discovery and trust.** The exact path
-  (`/-/pnpr/overrides` vs. a capabilities document), whether the document is
-  signed with the pnpr instance key in addition to being served over the
-  authenticated registry connection, and how a client maps multiple
+- **Document endpoint discovery and trust.** The exact path
+  (`/-/pnpr/patched-versions` vs. a capabilities document), whether the
+  document is signed with the pnpr instance key in addition to being served
+  over the authenticated registry connection, and how a client maps multiple
   configured registries to multiple documents (fetch from each base? default
   registry only?).
 - **pnpm-side application semantics.** Does pnpm apply a registry-provided
-  overrides document by default when the registry offers one, or behind a
-  setting? How is its provenance surfaced (`pnpm why`, lockfile comment,
-  install summary)? These belong in the pnpm follow-up RFC, but the answers
-  shape the document format.
+  patched-versions document by default when the registry offers one, or
+  behind a setting? What is the per-package opt-out surface, and how is
+  provenance surfaced (`pnpm why`, install summary)? How does an existing
+  lockfile interact with a changed document — re-resolve only on ordinary
+  re-resolution events, or also when the document digest changes? These
+  belong in the pnpm follow-up RFC, but the answers shape the document
+  format.
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the
   right delivery, and is the fallback a name-filtered bulk lookup, a

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -354,9 +354,22 @@ is pnpm's already-shipped alias machinery, and that is the point:
   resolution is made. An existing lockfile entry is never touched, and a
   `--frozen-lockfile` install neither fetches nor applies the document.
   Substitute at resolution, never at fetch.
+- **Applied registry overrides are recorded in the lockfile.** pnpm already
+  records the overrides a resolution used, and registry-provided entries
+  must leave the same trace: every entry that actually affected the graph is
+  written to a dedicated lockfile section (entry plus source registry) —
+  but *only* applied entries, so the lockfile grows with the workspace's
+  substitutions, not with the org's whole patch catalog. The record serves
+  both audiences: humans and SBOM tooling see *why* `ejs` resolves to
+  `@echo-patch/ejs@2.7.4`, and pnpm gets change detection — a changed or
+  withdrawn entry re-resolves exactly the affected packages, and a new
+  document entry covering a currently locked vulnerable pick adopts the
+  patch on the next non-frozen install (a map lookup over locked
+  `name@version` pairs, no re-resolution sweep).
 - **Provenance is legible and diffable.** The lockfile shows `ejs` resolving
-  to `@echo-patch/ejs@2.7.4`; when a manifest refresh moves a patch to
-  `-sp2`, the next non-frozen resolution produces a reviewable lockfile diff.
+  to `@echo-patch/ejs@2.7.4` and the recorded entry that caused it; when a
+  manifest refresh moves a patch to `-sp2`, the next non-frozen resolution
+  produces a reviewable lockfile diff in both places.
 - **Opting out is ordinary precedence.** A workspace that must keep a
   vulnerable original declares its own override for `ejs@2.7.4` (mapping the
   pick to itself), which outranks the registry-provided document — visible
@@ -717,10 +730,16 @@ Tests should cover, at minimum:
   behavior change), whether a registry-provided document is applied by
   default or behind a setting, how provenance is surfaced (`pnpm why`,
   install summary), the exact once-only application rule for substituted
-  targets, whether parent-scoped selectors (`a>b@1.0.0`) participate, and
-  how an existing lockfile interacts with a changed document — re-resolve
-  only on ordinary re-resolution events, or also when the document digest
-  changes? The answers shape the document format.
+  targets, and whether parent-scoped selectors (`a>b@1.0.0`) participate.
+  The answers shape the document format.
+- **Lockfile recording shape.** The name and format of the lockfile section
+  recording applied registry overrides (alongside the existing `overrides`
+  record), whether the document digest is recorded in addition to the
+  applied entries, and the adoption-timing default — is silently adopting a
+  newly published patch for an already-locked pick on the next non-frozen
+  install the right behavior, or should new adoptions require an explicit
+  gesture (`pnpm update --patches`-style) while only *withdrawn* entries act
+  automatically?
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the
   right delivery, and is the fallback a name-filtered bulk lookup, a

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -296,7 +296,8 @@ Advertise mode's audit enrichment already computes, per vulnerable version,
 the substitution a workspace should adopt. `substitute` mode serves that
 same result wholesale: the registry compiles the pinned, policy-filtered
 manifests into one **patched-versions document** — a flat map from exact
-original versions to alias specs — at a well-known endpoint on each registry
+original versions to alias specs, each carrying the manifest-pinned
+integrity of the patched tarball — at a well-known endpoint on each registry
 base that enables it:
 
 ```jsonc
@@ -304,8 +305,14 @@ base that enables it:
 {
   "schema": "pnpr-patched-versions/1",
   "versions": {
-    "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4",
-    "lodash@4.17.20": "npm:@echo-patch/lodash@4.17.20"
+    "ejs@2.7.4": {
+      "spec": "npm:@echo-patch/ejs@2.7.4",
+      "integrity": "sha512-..."
+    },
+    "lodash@4.17.20": {
+      "spec": "npm:@echo-patch/lodash@4.17.20",
+      "integrity": "sha512-..."
+    }
   }
 }
 ```
@@ -338,7 +345,8 @@ the new behavior covers exactly the picks that previously slipped through —
 which is what the override's author meant all along. The substitution is
 applied exactly once (a substituted target is not re-matched, so maps
 cannot chain or cycle). Because the document's entries are all
-exact-version→exact-spec, they are ordinary overrides under this extension,
+exact-version→exact-spec, they are ordinary overrides under this extension
+— each with a pinned integrity riding along, the way a lockfile pins one —
 and the registry document is merged beneath the workspace's own overrides
 as the lowest-precedence source. Version selection is never changed — only
 which *build* of the selected version is installed. Everything downstream
@@ -385,22 +393,23 @@ route cannot distinguish a fresh resolution from an old pinned one, so
 which is precisely what "no known-patchable vulnerable artifact leaves this
 registry" means. The default is `serve`.
 
-**Resolution cost.** Matching is a map lookup per pick — free for the
-unpatched majority. A matched pick triggers resolving the alias target: an
-exact-version resolution against the patch-scope packument. That is a second
-resolution of *that dependency*, never of the graph, and the original pick
-is not wasted work — it is the key that selects the patch, and there is no
-way to learn that `^2.7.0` lands on `2.7.4` without performing the pick. The
-marginal cost over a hand-written alias override is therefore one extra
-packument fetch per patched package, against a packument that is small
-(patched versions only) and cached like any other. Even that fetch is
-optimizable to zero: the document derives from a manifest that already pins
-the patched tarball's integrity, so entries can optionally carry it — the
-canonical tarball URL is computable from registry config, letting the client
-construct the substituted resolution with no additional metadata request and
-read the manifest for subtree resolution from the tarball it will fetch
-regardless. Server-side, the map and the patch-scope metadata are local, so
-substitution is a lookup.
+**Resolution cost: substitution is free by construction.** Matching is a
+map lookup per pick — nothing for the unpatched majority. A matched pick
+does not trigger a second metadata resolution either, because the entry
+carries everything a registry resolution consists of: the exact
+name-and-version (from `spec`) and the tarball integrity (from
+`integrity`), with the canonical tarball URL computable from registry
+config. The client constructs the substituted resolution directly — no
+patch-scope packument fetch — and reads the manifest for subtree resolution
+from the tarball it will fetch regardless. The original pick is not wasted
+work: it is the key that selects the patch, and there is no way to learn
+that `^2.7.0` lands on `2.7.4` without performing the pick. Carrying the
+integrity is also a provenance property, not only a shortcut: the
+substituted tarball is verified against the manifest-pinned digest the same
+way a locked resolution is, so a compromised patch source cannot serve
+different bytes than the provider's signed manifest promised — on the very
+first install, before any lockfile exists. Server-side, the map and the
+patch-scope metadata are local, so substitution is a lookup there too.
 
 **Server-side and client-side resolution apply the same map at the same
 point.** The flow above is client-side resolution: pnpm reads packuments,
@@ -423,10 +432,10 @@ Costs and requirements, stated honestly:
 
 - **Automatic protection reaches only patch-aware clients.** npm and yarn
   users get advertise-mode discovery (and `refuse`, where enabled). pnpr is
-  pnpm-first, and the document format is deliberately trivial — exact version
-  in, alias spec out — so other tools can consume it, and an org can still
-  mechanically derive blunt bare-name overrides from it for clients that
-  predate the feature.
+  pnpm-first, and the document format is deliberately trivial — exact
+  version in; alias spec and integrity out — so other tools can consume it,
+  and an org can still mechanically derive blunt bare-name overrides from it
+  for clients that predate the feature.
 - **Provider retention becomes load-bearing.** A lockfile aliasing
   `@echo-patch/ejs@2.7.4` installs only while that artifact remains
   available. Providers must treat their patch namespaces as immutable and
@@ -453,9 +462,10 @@ prefers.
 **Document size.** The document grows linearly with the provider's patch
 catalog, and that catalog is advisory-driven: an entry exists only for an
 exact `name@version` that has a backported fix, so growth tracks CVE history
-in patched packages, not the registry. Realistic catalogs are on the order of
-10³–10⁴ entries; at roughly 80 bytes per entry that is sub-megabyte raw, and
-the shape (one scope prefix, repeated names) compresses to tens of kilobytes.
+in patched packages, not the registry. Realistic catalogs are on the order
+of 10³–10⁴ entries; at roughly 200 bytes per entry — the sha512 integrity
+dominates, and hash bytes do not compress — that is a couple of megabytes
+raw and on the order of a megabyte on the wire at the high end.
 Policy filtering (`minSeverity`, `requireAdvisoryMatch`) trims it further.
 Delivery cost is bounded by the caching contract rather than the size: the
 document changes only on manifest refresh or config reload, so a client
@@ -648,9 +658,10 @@ mount graph, routing, or the packument/tarball serving paths:
    Validate the policy block (known provider, mode, severity gate,
    `unawareClients`, one substituting provider per original `name@version`
    per mount); compile the pinned, policy-filtered manifests into the
-   `/-/pnpr/patched-versions` document with a digest/ETag, recompiled only on
-   manifest refresh or config reload; implement `unawareClients: refuse` on
-   the tarball route with the `403` reason body.
+   `/-/pnpr/patched-versions` document — each entry carrying the
+   manifest-pinned integrity of its patched tarball — with a digest/ETag,
+   recompiled only on manifest refresh or config reload; implement
+   `unawareClients: refuse` on the tarball route with the `403` reason body.
 5. **Server-side resolution integration.** Where pnpr resolves on the
    client's behalf (the resolution endpoint of the auth-aware
    resolution-cache design), apply the pinned map post-pick before a
@@ -681,7 +692,8 @@ Tests should cover, at minimum:
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
 - the patched-versions document compiled from pinned manifests, filtered by
-  `minSeverity`, stable between refreshes, and served with a digest/ETag;
+  `minSeverity`, stable between refreshes, served with a digest/ETag, and
+  carrying per-entry integrity equal to the manifest's;
 - packuments and tarball responses byte-identical with `patching:` enabled
   and disabled — substitute mode touches neither serving path;
 - an existing lockfile pinning the vulnerable original installing unchanged
@@ -786,12 +798,9 @@ Tests should cover, at minimum:
   automatically?
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the
-  right delivery, and is the fallback a name-filtered bulk lookup, a
-  chunked/delta encoding, or both?
-- **Document fast-path fields.** Should entries carry the patched artifact's
-  integrity (and possibly manifest essentials) so a client can construct the
-  substituted resolution without fetching the patch-scope packument — a
-  fatter document traded for zero extra metadata requests per substitution?
+  right delivery — integrity hashes dominate the bytes and do not compress —
+  and is the fallback a name-filtered bulk lookup, a chunked/delta encoding,
+  or both?
 - **Default mode.** Is `advertise` the right default for `patching:`, with
   `substitute` as the explicit escalation? (This RFC assumes yes: changing
   what fresh resolutions receive should be a deliberate, visible deployment

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -10,22 +10,23 @@ vendor is the declared origin), and a **patch scope** — the provider publishes
 patched artifacts under its own package namespace (`@echo-patch/ejs@2.7.4`),
 served through ordinary mounts and routes. A signed, pinned **patch
 manifest** ties the two names together, and a per-mount `patching:` policy
-applies it in one of two modes: **advertise**, where consumers adopt patches
-explicitly via package alias overrides
-(`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) surfaced through audit
-enrichment, and **substitute**, where pnpr annotates the vulnerable
-version's entry in served packuments with the patch mapping and a
-patch-aware resolver selects it: whenever resolution picks an annotated
-version, the resolver returns the provider's aliased artifact instead —
-recorded like an ordinary alias, with a canonical, host-free lockfile
-resolution — while already-pinned installs are never altered.
+applies it in one of two modes. Both serve the same per-version
+**annotation** on the vulnerable version's packument entry, which a
+patch-aware resolver acts on **after version selection**: whenever
+resolution picks an annotated version, it returns the provider's aliased
+artifact instead — recorded like an ordinary alias, with a canonical,
+host-free lockfile resolution — while already-pinned installs are never
+altered. The modes differ only in the client posture the annotation
+requests: **advertise** substitutes only for patches the workspace has
+explicitly accepted (discovered through audit enrichment, accepted by hand
+or via `pnpm audit --fix`), while **substitute** substitutes by default,
+with a per-package ignore list to refuse.
 
 Notably, this requires **no new mount kind**. Both shapes are expressible
 with hosted/upstream/router mounts as already specified; the only
-serving-path addition is the substitute-mode annotation, layered onto
-affected packuments on egress over a pristine cache. What this RFC adds is
-the manifest protocol, that annotation, and the audit/advisory machinery
-around them.
+serving-path addition is the annotation, layered onto affected packuments
+on egress over a pristine cache. What this RFC adds is the manifest
+protocol, that annotation, and the audit/advisory machinery around them.
 
 Both shapes extend the invariants of the registry-mounts RFC rather than
 weakening them:
@@ -227,52 +228,43 @@ package versions to their patched counterparts:
   because adoption is always an exact pin produced from the manifest — no
   range resolution against upstream expectations ever happens there.
 
-### Advertise mode: explicit adoption via alias overrides
+### Advertise mode: discovery and explicit acceptance
 
-In `advertise` mode, adoption is a **package alias override** in the consuming
-workspace — the mechanism pnpm already has for substituting one package for
-another:
+In `advertise` mode the registry surfaces available patches but substitutes
+nothing by default: adoption is an explicit, reviewable workspace decision.
+The mechanics are the same annotation and patch-aware resolver as substitute
+mode (below) — the annotation simply requests an **opt-in posture**. Three
+adoption paths:
 
-```jsonc
-{
-  "pnpm": {
-    "overrides": {
-      "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"
-    }
-  }
-}
-```
-
-One property of overrides matters here: an override rewrites the **declared
-specs** in `package.json` files, and its selector matches a declared range by
-subset. The exact-version key above therefore covers dependencies declared as
-`2.7.4` (typical for lockstep pins and many transitive declarations) but
-*not* a dependency declared as `^2.7.0` — no selector short of the bare name
-matches that, and a bare-name override
-(`"ejs": "npm:@echo-patch/ejs@2.7.4"`) also *forces* the version for every
-`ejs` in the graph. Both are legitimate hand-written choices — visible,
-reviewable, deliberate — but the range case is handled properly by substitute
-mode (below), which is applied after version selection instead of to specs.
-
-Three adoption paths, from least to most automatic:
-
-1. **Hand-written overrides**, as above. Works today with no pnpr or pnpm
-   changes; the alias installs the patched bytes at every point in the graph
-   where `ejs@2.7.4` appeared, including transitive positions.
-2. **Audit enrichment.** pnpr implements the npm audit endpoints
+1. **Audit enrichment.** pnpr implements the npm audit endpoints
    (`/-/npm/v1/security/advisories/bulk`) against OSV plus the pinned
-   manifests, and reports, per vulnerable version, the exact override spec
+   manifests, and reports, per vulnerable version, the patched artifact
    available *on this registry*. The stock response format has no field for
-   "an aliased fix exists", so pnpr adds a namespaced extension field to each
-   advisory entry carrying the suggested override; clients that do not know
-   the field ignore it.
-3. **`pnpm audit --fix` (pnpm follow-up, out of scope here).** pnpm reads the
-   enriched audit response and writes the alias overrides mechanically. This
-   is deliberately a *write-my-config* flow: the override is visible in the
-   workspace manifest and lockfile, reviewable in the PR that introduces it,
-   and removable when the team upgrades away from the vulnerable base
-   version. (Registry-side resolution-time behavior is substitute mode,
-   below.)
+   "an aliased fix exists", so pnpr adds a namespaced extension field
+   carrying the mapping (`ejs@2.7.4 → npm:@echo-patch/ejs@2.7.4`); clients
+   that do not know the field ignore it.
+2. **Explicit acceptance (patch-aware clients).** The workspace lists
+   accepted patches in its config — per entry, or per provider — and the
+   patch-aware resolver substitutes exactly as in substitute mode, but only
+   for accepted entries. `pnpm audit --fix` (pnpm follow-up, out of scope
+   here) becomes mechanical: read the enriched audit response, append
+   accept-list entries — reviewable in the PR that introduces them,
+   removable after upgrading away. Because acceptance is applied by the
+   resolver **after version selection**, it correctly covers picks reached
+   through ranges — the case overrides cannot express, below.
+3. **Hand-written overrides (any npm-compatible client, today).** An alias
+   override adopts a patch with no new client feature — but overrides
+   rewrite *declared specs* by subset matching, and that has teeth:
+   `"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"` covers only dependencies
+   declared as exactly `2.7.4`, silently missing every `^2.7.0` that
+   resolves to `2.7.4`. Covering ranges requires keying by the declared
+   ranges themselves (`"ejs@^2.7.0": "npm:@echo-patch/ejs@2.7.4"`), which
+   *freezes* everything inside that range to the patched build — including
+   after upstream releases a fixed `2.7.5` — and misses differently-shaped
+   ranges added later; a bare-name key is the same trade graph-wide. This
+   path is honest and available, but it is a blunt instrument, not the
+   mechanism this RFC builds on — and it is why `pnpm audit --fix` writes
+   accept-list entries rather than overrides.
 
 What the alias buys over other encodings of "patched artifact":
 
@@ -289,19 +281,20 @@ What the alias buys over other encodings of "patched artifact":
   `npm outdated`, Renovate/Dependabot version filtering, semver-range
   tooling — never see a prerelease identifier on the adoption path.
 
-Advertise mode's limit is that it is **opt-in per workspace**: a fresh
-`pnpm install` in a repository that has not written the override resolves
-`^2.7.0` to the vulnerable original, exactly as before. Repositories that
-never run `pnpm audit` never find out. When the deployment's intent is "no
-fresh resolution may pick a version we have a patch for", that is substitute
-mode.
+Advertise mode's limit is deliberate: it is **opt-in per workspace**. A
+fresh `pnpm install` in a repository that has accepted nothing resolves
+`^2.7.0` to the vulnerable original, exactly as before, and repositories
+that never run `pnpm audit` never find out. When the deployment's intent is
+"no fresh resolution may pick a version we have a patch for", that is
+substitute mode.
 
 ### Substitute mode: annotated packuments selected by the resolver
 
-`substitute` mode puts the mapping where the resolver is already looking:
-on the vulnerable version's entry in the packument. For every manifest
-entry the mount's policy accepts, pnpr serves the base packument with an
-annotation on that version — original metadata and `dist` untouched:
+Both modes put the mapping where the resolver is already looking: on the
+vulnerable version's entry in the packument. For every manifest entry the
+mount's policy accepts, pnpr serves the base packument with an annotation on
+that version — original metadata and `dist` untouched — carrying the mode's
+requested posture:
 
 ```jsonc
 // GET /~main/ejs — versions["2.7.4"], annotated on egress
@@ -310,7 +303,8 @@ annotation on that version — original metadata and `dist` untouched:
   "_pnprPatch": {
     "patched": "npm:@echo-patch/ejs@2.7.4",
     "provider": "echo",
-    "fixes": ["GHSA-..."]
+    "fixes": ["GHSA-..."],
+    "apply": "default"        // advertise mode serves "opt-in"
   }
 }
 ```
@@ -333,7 +327,11 @@ mounts:
 The annotation is applied **on egress**: the cached upstream packument stays
 byte-identical to what the origin served, and the annotation is layered on
 at response time as a pure function of the pinned manifest snapshot. The
-field is inert for any client that does not know it.
+field is inert for any client that does not know it. In advertise mode the
+identical annotation is served with `apply: opt-in` and the resolver
+substitutes only workspace-accepted entries (previous section); the rest of
+this section describes the default-on posture that gives substitute mode its
+name.
 
 A patch-aware resolver (a pnpm follow-up RFC) selects the annotation
 *inside* the resolve call. pnpm's resolver already separates a dependency's
@@ -569,7 +567,10 @@ protection. Widening the selector cannot fix it: no range selector matches
 forces every `ejs` in the graph to the patched `2.7.4`, downgrading a
 `^2.7.0` that would have picked a genuinely fixed `2.7.5`. Any correct
 mechanism must act after version selection — spec rewriting cannot see the
-pick.
+pick. The same fact rules out `pnpm audit --fix` emitting overrides: an
+exact-version key would not apply to range declarations, and range or
+bare-name keys freeze or force version selection — which is why the fix
+flow writes accept-list entries for the patch-aware resolver instead.
 
 ### A standalone patched-versions document plus an override extension
 
@@ -660,12 +661,12 @@ pristine cached packuments:
    version.
 4. **Per-mount `patching:` policy and the egress annotation.** Validate the
    policy block (known provider, mode, severity gate, `unawareClients`, one
-   substituting provider per original `name@version` per mount); in
-   substitute mode, annotate matched version entries of served packuments
-   on egress as a pure function of the pinned snapshots, leaving cached
-   upstream documents and every `dist` object untouched; implement
-   `unawareClients: refuse` on the tarball route with the `403` reason
-   body.
+   substituting provider per original `name@version` per mount); annotate
+   matched version entries of served packuments on egress with the mode's
+   requested posture (`apply: default` / `opt-in`), as a pure function of
+   the pinned snapshots, leaving cached upstream documents and every `dist`
+   object untouched; implement `unawareClients: refuse` on the tarball
+   route with the `403` reason body.
 5. **Server-side resolution integration.** Where pnpr resolves on the
    client's behalf (the resolution endpoint of the auth-aware
    resolution-cache design), apply the same annotation logic inside
@@ -673,12 +674,13 @@ pristine cached packuments:
    substitution marker, and include the patching policy and snapshot digest
    in resolution-cache keys.
 
-Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
-overrides from the enriched audit response, and the patch-aware resolver —
+Client-side follow-ups (separate pnpm RFC): the patch-aware resolver —
 selecting `_pnprPatch` inside the resolve call, returning the aliased
 identity (`resolvedVia: registry-patch`), recording substituted entries in
-a dedicated lockfile section so satisfiability checks accept them, with an
-explicit ignore setting for opting out.
+a dedicated lockfile section so satisfiability checks accept them, and
+honoring the posture through accept lists (opt-in annotations) and ignore
+lists (default annotations) — plus `pnpm audit --fix` writing accept-list
+entries from the enriched audit response.
 
 Tests should cover, at minimum:
 
@@ -696,7 +698,9 @@ Tests should cover, at minimum:
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
 - matched version entries annotated on egress only for manifest-covered,
-  policy-accepted versions, as a pure function of the pinned snapshot;
+  policy-accepted versions, as a pure function of the pinned snapshot,
+  carrying `apply: opt-in` in advertise mode and `apply: default` in
+  substitute mode;
 - cached upstream packuments staying byte-identical to origin (annotation
   on egress only), every `dist` object and all tarball responses identical
   with `patching:` enabled and disabled;
@@ -807,11 +811,11 @@ Tests should cover, at minimum:
   squatting on the public registry is a consideration when the patch source
   is also reachable as a plain npm registry.
 - **Alias-override support matrix.** pnpm supports `npm:` aliases in
-  overrides; verify the exact behavior in npm's `overrides` and yarn's
-  `resolutions` so the audit-suggested spec works (or degrades clearly)
-  across clients.
+  overrides; verify the exact selector-matching and alias behavior in npm's
+  `overrides` and yarn's `resolutions` so the documented hand-written path
+  (range-keyed alias overrides) works, or degrades clearly, across clients.
 - **Audit extension field shape.** The exact name and structure of the
-  namespaced field carrying the suggested override in the bulk-advisories
+  namespaced field carrying the patch mapping in the bulk-advisories
   response, and whether `pnpm audit` should render it without the `--fix`
   follow-up.
 - **SBOM/upstream identity mapping.** License and SBOM tooling will record
@@ -825,10 +829,12 @@ Tests should cover, at minimum:
 - **Patch-aware resolver design.** The pnpm-side follow-up must settle
   whether annotations are honored by default when present or behind a
   setting, whether they are honored from *any* registry or only from
-  configured pnpr bases, the opt-out surface (ignore list per package or
-  per provider), how provenance is surfaced (`pnpm why`, install summary,
-  the `resolvedVia` marker), and the annotation field name (`_pnprPatch`
-  vs. something vendor-neutral other resolvers could adopt).
+  configured pnpr bases, the shape of the opt-in and opt-out surfaces
+  (accept list for `apply: opt-in` annotations, ignore list for
+  `apply: default` ones — per package or per provider), how provenance is
+  surfaced (`pnpm why`, install summary, the `resolvedVia` marker), and the
+  annotation field name (`_pnprPatch` vs. something vendor-neutral other
+  resolvers could adopt).
 - **Lockfile recording shape.** The name and format of the lockfile section
   recording substituted entries — it must let satisfiability checks accept
   an aliased resolution the workspace's own config does not explain, and

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -13,15 +13,18 @@ manifest** ties the two names together, and a per-mount `patching:` policy
 applies it in one of two modes: **advertise**, where consumers adopt patches
 explicitly via package alias overrides
 (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) surfaced through audit
-enrichment, and **substitute**, where pnpr rewrites the vulnerable version's
-`dist` in served packuments so that *fresh resolutions* automatically receive
-the patched artifact — visibly recorded in the resulting lockfile — while
-already-pinned installs are never altered.
+enrichment, and **substitute**, where the registry compiles the manifest into
+a ready-made **overrides object** served at a well-known endpoint, which
+patch-aware clients fetch and apply automatically at resolution — so *fresh
+resolutions* receive the patched artifact as an ordinary recorded alias with
+a canonical, host-free lockfile resolution, while already-pinned installs are
+never altered.
 
-Notably, this requires **no new mount kind**. Both shapes are expressible with
+Notably, this requires **no new mount kind** and no changes to how packuments
+or tarballs are served. Both shapes are expressible with
 hosted/upstream/router mounts as already specified; what this RFC adds is the
-manifest protocol, a packument rewrite step attached to existing mounts, and
-the audit/advisory machinery around it.
+manifest protocol, a registry-served overrides document, and the
+audit/advisory machinery around it.
 
 Both shapes extend the invariants of the registry-mounts RFC rather than
 weakening them:
@@ -275,11 +278,24 @@ never run `pnpm audit` never find out. When the deployment's intent is "no
 fresh resolution may pick a version we have a patch for", that is substitute
 mode.
 
-### Substitute mode: automatic patching of fresh resolutions
+### Substitute mode: a registry-provided overrides object
 
-`substitute` mode makes the registry apply the manifest itself, at
-**resolution time**. The `patching:` policy attaches to any read-serving
-mount (upstream or router) and rewrites the packuments that mount serves:
+Advertise mode's audit enrichment already computes, per vulnerable version,
+the exact override a workspace should adopt. `substitute` mode serves that
+same result wholesale: the registry compiles the pinned, policy-filtered
+manifests into one **overrides object** — in pnpm's own overrides format —
+at a well-known endpoint on each registry base that enables it:
+
+```jsonc
+// GET <registry base>/-/pnpr/overrides
+{
+  "schema": "pnpr-overrides/1",
+  "overrides": {
+    "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4",
+    "lodash@4.17.20": "npm:@echo-patch/lodash@4.17.20"
+  }
+}
+```
 
 ```yaml
 mounts:
@@ -293,79 +309,71 @@ mounts:
     patching:
       provider: echo
       mode: substitute
-      minSeverity: high      # only substitute for fixes at/above this severity
+      minSeverity: high      # only include fixes at/above this severity
 ```
 
-For every manifest entry `ejs@2.7.4 → @echo-patch/ejs@2.7.4`, the served
-packument for `ejs` keeps the version `2.7.4` — same version list, same
-dist-tags — but that version's `dist` now carries the **patched artifact's
-tarball URL and integrity**, plus a marker object naming the provider, the
-patched identity, and the advisories fixed:
+A patch-aware client (a small pnpm follow-up) fetches the document once per
+resolution run and merges it at the **lowest precedence** — anything the
+workspace declares wins — exactly as if the workspace had written those
+overrides by hand. Everything downstream is pnpm's already-shipped alias
+machinery, and that is the point:
 
-```jsonc
-"2.7.4": {
-  // ...original metadata...
-  "dist": {
-    "tarball": "https://<pnpr>/~echo-patches/@echo-patch/ejs/-/ejs-2.7.4.tgz",
-    "integrity": "sha512-<patched>"
-  },
-  "_pnprPatch": {
-    "of": "ejs@2.7.4",
-    "patched": "@echo-patch/ejs@2.7.4",
-    "provider": "echo",
-    "fixes": ["GHSA-..."]
-  }
-}
-```
+- **The lockfile stays canonical and host-free.** A fresh resolution of
+  `^2.7.0` picks `2.7.4`, the override redirects it, and the lockfile records
+  the aliased package `@echo-patch/ejs@2.7.4` with a canonical resolution —
+  integrity only, tarball URL recomputed from registry config at install
+  time. Nothing deployment-specific is persisted; portability is exactly that
+  of any aliased dependency.
+- **No pinned install ever changes.** Overrides act only when a resolution is
+  made. An existing lockfile entry is never touched, and a
+  `--frozen-lockfile` install neither fetches nor applies the document.
+  Substitute at resolution, never at fetch.
+- **Provenance is legible and diffable.** The lockfile shows `ejs` resolving
+  to `@echo-patch/ejs@2.7.4`; when a manifest refresh moves a patch to
+  `-sp2`, the next non-frozen resolution produces a reviewable lockfile diff.
+- **Opting out is ordinary config.** A workspace that must keep the
+  vulnerable original pins it with its own override, which outranks the
+  registry-provided one — visible and reviewable, like every other override.
 
-Why this is safe where fetch-time byte swapping is not:
+Clients that are not patch-aware never ask for the document and resolve the
+vulnerable original — no worse than today. Per-mount policy can escalate:
+`unawareClients: refuse` makes the tarball route answer a manifest-covered
+vulnerable artifact with the explicit `403`-plus-suggested-override body
+instead of bytes. That is hard enforcement, stated honestly: the tarball
+route cannot distinguish a fresh resolution from an old pinned one, so
+`refuse` also blocks existing lockfiles that pin the vulnerable original —
+which is precisely what "no known-patchable vulnerable artifact leaves this
+registry" means. The default is `serve`.
 
-- **No pinned install ever changes.** An existing lockfile that resolved the
-  original `ejs@2.7.4` holds the original integrity and reconstructs the
-  canonical tarball URL (`<base>/ejs/-/ejs-2.7.4.tgz`) — which continues to
-  serve the original base-origin bytes, forever. Substitution happens only in
-  the *metadata that new resolutions read*, never on the tarball route.
-- **The substitution is recorded, not hidden.** The patched tarball URL is
-  non-canonical for the package name `ejs`, so pnpm's lockfile writer
-  persists it in full (this is existing behavior for non-canonical
-  resolutions). The resulting lockfile literally shows
-  `@echo-patch/ejs` in the resolution of `ejs@2.7.4` — reviewable in the PR
-  that first creates it, diffable when a patch revision changes it, and
-  reproducible thereafter because the URL and integrity pin exact bytes.
-- **Deterministic between manifest refreshes.** Which versions are rewritten
-  is a pure function of the mount's `patching:` config plus the pinned
-  manifest snapshot — the same determinism contract as router routes. A
-  refresh that changes any substitution is logged and diffable.
-- **The version number still tells the truth.** The application resolves,
-  installs, and runs `2.7.4` — the patched build of it, from a declared
-  provider namespace, with the provenance one `dist.tarball` away.
+Costs and requirements, stated honestly:
 
-Costs, stated honestly:
-
-- **Lockfile portability.** The persisted patched tarball URL embeds the pnpr
-  deployment host, which the mounts RFC works hard to keep out of lockfiles.
-  The exposure is limited to substituted entries, but moving a deployment
-  means those entries must be re-resolved (or rewritten by a future
-  registry-identity-aware lockfile format, which would restore portability
-  for patched entries too).
-- **Provider retention becomes load-bearing.** A lockfile pointing at
+- **Automatic protection reaches only patch-aware clients.** npm and yarn
+  users get advertise-mode discovery (and `refuse`, where enabled). pnpr is
+  pnpm-first, and the document is deliberately pnpm's overrides shape so
+  other tools can consume it too — an org can even paste it into a shared
+  config today.
+- **Provider retention becomes load-bearing.** A lockfile aliasing
   `@echo-patch/ejs@2.7.4` installs only while that artifact remains
   available. Providers must treat their patch namespaces as immutable and
   permanent (the manifest protocol should say so), and pnpr's per-mount cache
   keeps serving cached patched artifacts through provider outages, like any
   other mount content.
-- **Range semantics shift by one policy layer.** Two workspaces resolving the
-  same range through mounts with different `patching:` policies get different
-  bytes (same version, different builds). That is the deployment's declared
+- **Same range, different policies, different bytes.** Two workspaces
+  resolving the same range through mounts with different `patching:` policies
+  get the same version as different builds. That is the deployment's declared
   intent — but it is one more reason registry identity belongs in package
   identity.
 
-One rule guards against silent conflicts: within one mount, at most one
-provider may substitute for a given original `name@version`; two manifests
-claiming the same original is a config error, not a precedence guess. And
-substitution composes with advertise-mode machinery — the audit endpoint
-still reports the mapping, so a workspace can see which of its resolutions
-were substituted and pin them explicitly if it prefers.
+Determinism and conflicts: the served overrides object is a pure function of
+the mount's `patching:` config plus the pinned manifest snapshots — the same
+determinism contract as router routes. A refresh that changes it is logged
+and diffable, and the document carries a digest/ETag so clients cache it
+cheaply. Within one mount, at most one provider may claim a given original
+`name@version`; two manifests colliding is a config error, not a precedence
+guess. And substitution composes with advertise-mode machinery — the audit
+endpoint still reports the mapping, so a workspace can see which of its
+resolutions came from the registry's overrides and pin them explicitly if it
+prefers.
 
 ### Advisory screening of patched artifacts
 
@@ -399,13 +407,12 @@ Its advantage is discoverability in one namespace: the patched versions appear
 in `npm view ejs versions`, and adoption is a version-only override with no
 name change. It is rejected as the primary mechanism because:
 
-- **It synthesizes more metadata for less.** The overlay serves a packument
-  that no single origin published — base metadata with foreign *version
-  entries* spliced into the version list. Substitute mode's rewrite is
-  strictly narrower (one `dist` object under an existing version, marked as
-  such), and advertise mode needs no rewriting at all — yet grafting buys
-  neither automatic protection (last bullet below) nor a cleaner adoption
-  story.
+- **It synthesizes metadata.** The overlay serves a packument that no single
+  origin published — base metadata with foreign *version entries* spliced
+  into the version list. The alias model never modifies a served packument in
+  any mode: the overrides document lives beside the registry surface, not
+  inside another origin's metadata — yet grafting buys neither automatic
+  protection (last bullet below) nor a cleaner adoption story.
 - **It requires a new composite mount kind**, with its own validation, routing,
   write-rejection, and access-composition rules. The alias model is ordinary
   packages through ordinary mounts.
@@ -438,10 +445,35 @@ the moment a patch appears, shared caches become ambiguous about which bytes
 are "the" version, and nothing in any lockfile records that a substitution
 happened. Substitute mode has none of these properties: the original
 canonical URL serves original bytes forever, and the patched artifact enters
-only through *new resolutions*, under its own URL and integrity, recorded in
-the lockfile. Organizations that want fetch-level same-version patching have
+only through *new resolutions*, under its own aliased identity and integrity,
+recorded in the lockfile. Organizations that want fetch-level same-version
+patching have
 a coherent home for it: make the vendor the declared origin (upstream mount),
 where the vendor owns the identity end to end.
+
+### Serving the substitution inside packuments
+
+Two earlier shapes of substitute mode put the mapping into the served
+packument itself instead of a separate overrides document:
+
+- **Rewrite the vulnerable version's `dist`** to the patched artifact's
+  tarball URL and integrity. Its appeal is universality — every npm client
+  gets auto-patched with no client feature — but the patched URL is
+  non-canonical for the original name, so clients persist the full URL,
+  baking the deployment host into lockfiles: exactly what the mounts RFC's
+  canonical-URL round-tripping exists to prevent. The lockfile records an
+  opaque URL where the alias encoding records a first-class package identity
+  with a canonical, recomputable resolution.
+- **Annotate the vulnerable version** with an extension field
+  (`_pnprPatch: {patched, integrity, ...}`) for patch-aware clients to act
+  on. Lockfile-clean, but it still injects nonstandard fields into another
+  origin's metadata on the serving path, and the client must discover
+  patches one packument at a time.
+
+The registry-provided overrides object subsumes both: the same information,
+one standard-shaped document beside the registry surface, zero changes to
+packument or tarball serving — and the client-side behavior it enables is
+identical to overrides the workspace could have written itself.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -480,9 +512,8 @@ except the specific, signed, advisory-matched artifacts the provider patched.
 
 ## Implementation
 
-All registry-side changes are in pnpr-server, and none of them change the
-mount graph or routing; substitute mode adds one rewrite step on the
-packument-serving path:
+All registry-side changes are in pnpr-server, and none of them touch the
+mount graph, routing, or the packument/tarball serving paths:
 
 1. **`patchProviders:` config and manifest machinery.** Parse/validate the
    provider block (scope, source mount, manifest URL, keys, policy);
@@ -497,15 +528,17 @@ packument-serving path:
    endpoint from OSV data, adding the namespaced extension field with the
    suggested override spec when a pinned manifest covers a vulnerable
    version.
-4. **Per-mount `patching:` policy and the substitute rewriter.** Validate the
-   policy block (known provider, mode, severity gate, one substituting
-   provider per original `name@version` per mount); in substitute mode,
-   rewrite matched versions' `dist` to the patched artifact's URL and
-   integrity and attach the `_pnprPatch` marker, leaving version lists,
-   dist-tags, and the tarball routes untouched.
+4. **Per-mount `patching:` policy and the overrides endpoint.** Validate the
+   policy block (known provider, mode, severity gate, `unawareClients`, one
+   substituting provider per original `name@version` per mount); compile the
+   pinned, policy-filtered manifests into the `/-/pnpr/overrides` document
+   with a digest/ETag, recompiled only on manifest refresh or config reload;
+   implement `unawareClients: refuse` on the tarball route with the `403`
+   reason body.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
-overrides from the enriched audit response.
+overrides from the enriched audit response, and fetch-and-merge of the
+registry-provided overrides document at lowest precedence during resolution.
 
 Tests should cover, at minimum:
 
@@ -522,16 +555,19 @@ Tests should cover, at minimum:
   patch against the same base version;
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
-- substitute mode rewriting `dist` (URL, integrity, marker) for matched
-  versions on fresh packument reads while the canonical tarball URL for the
-  original version keeps serving the original bytes;
-- an existing lockfile pinning the original version installing unchanged
-  through a substitute-mode mount (canonical URL reconstruction + original
-  integrity);
-- severity gating (`minSeverity`) and the one-substituting-provider-per-
-  original rule enforced at config load;
-- a manifest refresh changing a substitution being logged, and prior patched
-  URLs continuing to serve as long as the provider retains them;
+- the overrides document compiled from pinned manifests, filtered by
+  `minSeverity`, stable between refreshes, and served with a digest/ETag;
+- packuments and tarball responses byte-identical with `patching:` enabled
+  and disabled — substitute mode touches neither serving path;
+- an existing lockfile pinning the vulnerable original installing unchanged
+  through a substitute-mode mount (with `unawareClients: serve`);
+- `unawareClients: refuse` answering manifest-covered vulnerable tarballs
+  with `403` plus the suggested override, and leaving uncovered artifacts
+  untouched;
+- the one-substituting-provider-per-original rule enforced at config load;
+- a manifest refresh changing the overrides document being logged, and
+  previously aliased patched artifacts continuing to serve as long as the
+  provider retains them;
 - vendor-as-origin deployments (Seal-style `-spN` packuments) proxying
   unchanged through an upstream mount.
 
@@ -550,6 +586,11 @@ Tests should cover, at minimum:
   mechanism this design rides on; pnpm supports aliases both as dependencies
   and as override targets, which is what makes adoption a config edit rather
   than a client feature.
+- **pnpm's config dependencies** (RFC 0004) already distribute shared
+  overrides to many repositories through an installed package; the
+  registry-provided overrides document is the same idea with the registry as
+  the distribution channel, and the two can coexist (an org can compile the
+  document into a config dependency for clients that predate the endpoint).
 - **vlt's DepID** (registry as a component of package identity) is the prior
   art for the deferred named-registry encoding.
 - **Socket Certified Patches** demonstrates the repo-local patching shape;
@@ -587,20 +628,24 @@ Tests should cover, at minimum:
   upstream identity) as an endpoint so downstream tooling can resolve it, or
   is the provider's attestation the right carrier?
 - **Named-registry encoding timing.** Revisit `echo:ejs@2.7.4`-style
-  overrides once the pnpm lockfile registry-identity follow-up lands. That
-  work would also restore lockfile portability for substitute-mode entries
-  (registry identity instead of an absolute patched-tarball URL).
-- **Substitute-mode opt-out surface.** Should a workspace be able to refuse
-  substitution for a specific package (pin the vulnerable original
-  deliberately) without addressing the base mount directly — e.g., an
-  override on the original canonical spec — and should pnpr honor or flag
-  that?
+  overrides once the pnpm lockfile registry-identity follow-up lands; the
+  overrides document could then carry registry-qualified specs as an
+  alternative encoding.
+- **Overrides endpoint discovery and trust.** The exact path
+  (`/-/pnpr/overrides` vs. a capabilities document), whether the document is
+  signed with the pnpr instance key in addition to being served over the
+  authenticated registry connection, and how a client maps multiple
+  configured registries to multiple documents (fetch from each base? default
+  registry only?).
+- **pnpm-side application semantics.** Does pnpm apply a registry-provided
+  overrides document by default when the registry offers one, or behind a
+  setting? How is its provenance surfaced (`pnpm why`, lockfile comment,
+  install summary)? These belong in the pnpm follow-up RFC, but the answers
+  shape the document format.
 - **Default mode.** Is `advertise` the right default for `patching:`, with
-  `substitute` as the explicit escalation? (This RFC assumes yes: silent
-  byte-provenance changes on fresh resolutions should be a deliberate,
-  visible deployment decision.)
-- **Marker field name.** `_pnprPatch` vs. something vendor-neutral tooling
-  could standardize on.
+  `substitute` as the explicit escalation? (This RFC assumes yes: changing
+  what fresh resolutions receive should be a deliberate, visible deployment
+  decision.)
 - **Interaction with package screening.** The separate screening RFC's block
   responses could advertise "a patched artifact is available" via the same
   manifest data. That integration is optional in both directions; neither RFC

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -99,7 +99,8 @@ registries:
     type: hosted
     org: acme
     access: team:acme
-    patterns: ['@acme/*']
+    packages:
+      '@acme/*': {}
 
   echo:
     type: upstream
@@ -107,7 +108,7 @@ registries:
     auth:
       tokenEnv: ECHO_NPM_TOKEN
     access: team:acme
-    # No patterns: serves every name — the router's catch-all.
+    # No packages map: serves every name — the router's catch-all.
 
   main:
     type: router
@@ -156,7 +157,7 @@ registries:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
-    # No patterns: serves every name — the router's catch-all.
+    # No packages map: serves every name — the router's catch-all.
 
   echo-patches:
     type: upstream
@@ -164,7 +165,8 @@ registries:
     auth:
       tokenEnv: ECHO_NPM_TOKEN
     access: team:acme
-    patterns: ['@echo-patch/*']
+    packages:
+      '@echo-patch/*': {}
 
   main:
     type: router
@@ -185,16 +187,17 @@ patchProviders:
 
 No new registry kind and no fall-through anywhere: the patch scope is just
 packages. The patch-source registry **declares the provider's scope as its
-namespace** (`patterns: ['@echo-patch/*']`), so routers claim it from that
-declaration, and the namespace is enforced on every path to the registry —
-`/~echo-patches/lodash` is a definitive `404`, which also stops any caller
-from pulling arbitrary public names through the provider's server-owned
-credential. Caching and access policies are the existing per-registry ones.
-The new configuration surface is `patchProviders:`, which registers the
-**manifest** that ties the two namespaces together — and which a registry's
-`patching:` policy (below) chooses how to apply. Validation requires the
-provider's `scope` to be claimed by its source registry's declared
-`patterns`.
+namespace** (a `packages:` map claiming `@echo-patch/*`), so routers claim
+it from that declaration, and the namespace is enforced on every path to
+the registry — `/~echo-patches/lodash` is a definitive `404`, which also
+stops any caller from pulling arbitrary public names through the provider's
+server-owned credential. Per-package `access` rules in the same map remain
+available for finer gating. Caching and access policies are the existing
+per-registry ones. The new configuration surface is `patchProviders:`,
+which registers the **manifest** that ties the two namespaces together —
+and which a registry's `patching:` policy (below) chooses how to apply.
+Validation requires the provider's `scope` to be claimed by its source
+registry's declared `packages` namespace.
 
 ### The patch manifest
 
@@ -655,11 +658,11 @@ routing are untouched; substitute mode adds one egress annotation step
 layered over pristine cached packuments:
 
 1. **`patchProviders:` config and manifest machinery.** Parse/validate the
-   provider block (scope, source registry — whose declared `patterns` must
-   claim the scope — manifest URL, keys, policy); fetch/verify/pin
-   manifests on the refresh interval with logged diffs; reject entries
-   outside the provider's scope, without integrity, or (under
-   `requireAdvisoryMatch`) without a known advisory in `fixes`.
+   provider block (scope, source registry — whose declared `packages`
+   namespace must claim the scope — manifest URL, keys, policy);
+   fetch/verify/pin manifests on the refresh interval with logged diffs;
+   reject entries outside the provider's scope, without integrity, or
+   (under `requireAdvisoryMatch`) without a known advisory in `fixes`.
 2. **Advisory identity mapping.** Screen patch-scope artifacts as their
    manifest-mapped upstream identity, minus the `fixes` list for the pinned
    integrity; apply the same mapping wherever advisories are evaluated
@@ -692,9 +695,9 @@ submitted alongside this one.
 Tests should cover, at minimum:
 
 - provider config validation (unknown source registry, a scope the source
-  registry's `patterns` do not claim, scope collisions between providers,
-  unsigned/tampered manifests, out-of-scope entries, missing integrity,
-  `requireAdvisoryMatch` violations);
+  registry's `packages` map does not claim, scope collisions between
+  providers, unsigned/tampered manifests, out-of-scope entries, missing
+  integrity, `requireAdvisoryMatch` violations);
 - manifest refresh changing derived data only at refresh, with the change
   logged;
 - patch-scope packages serving through ordinary routing with the source

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -211,9 +211,15 @@ package versions to their patched counterparts:
 - **Scope-bound.** Every `patched` entry must name a package inside the
   provider's declared scope; an entry pointing anywhere else is rejected at
   validation. A provider can describe only its own namespace.
-- **Integrity-pinned.** The manifest's integrity for the patched artifact must
-  match what the patch source serves; a mismatch is an error, never a
-  fall-through to the vulnerable original.
+- **Integrity-pinned, enforced at the serving path.** The patched content
+  originates from the provider's infrastructure — an origin the deployment
+  does not control — so pnpr is the boundary where the provider's signed
+  promise is enforced. For every manifest-listed version, the patch-scope
+  packument's `dist.integrity` must equal the manifest's pin, and fetched
+  tarball bytes are verified against it; a mismatch is an error, never a
+  fall-through to the vulnerable original. A compromised patch source can
+  therefore refuse to serve, but cannot serve different bytes through pnpr
+  than the signed manifest promised.
 - **Patch re-issues stay inside the namespace.** If a patch itself needs a
   second revision (a new CVE lands on the same base version), the provider
   publishes `@echo-patch/ejs@2.7.4-sp2` and updates the manifest entry.
@@ -395,16 +401,18 @@ dependency*, never of the graph, and the original pick is not wasted work —
 it is the key that selects the patch; there is no way to learn that
 `^2.7.0` lands on `2.7.4` without performing the pick. A fetch-free variant
 — carrying each patched tarball's integrity in the document so the client
-constructs the resolution directly — was considered and rejected: a
-hand-written override will never carry an integrity, so the mechanism would
-fork into two systems (or grow an object-form override type), and it
-crosses no trust boundary, because the document and the patch-scope
-packument are served by the same registry origin — pinning one to the other
-adds nothing a compromised registry could not rewrite in both. The
-end-to-end pin lives where it belongs: pnpr verifies patch-source bytes
-against the provider's *signed manifest* before serving them. Server-side,
-the map and the patch-scope metadata are local, so substitution is a lookup
-there.
+constructs the resolution directly — was considered and set aside: a
+hand-written override will never carry an integrity, so making integrity
+part of override semantics would fork the mechanism into two systems (or
+grow an object-form override type). The trust boundary it would police —
+the patch source's infrastructure, which the deployment does not control —
+is already policed server-side, where pnpr verifies both the patch-scope
+metadata and the tarball bytes against the provider's *signed manifest*
+before serving them (see the manifest rules). Client-carried integrity
+would defend only against pnpr itself failing to enforce that check —
+defense in depth, not a new guarantee — and is parked as an open question
+rather than a mechanism change. Server-side, the map and the patch-scope
+metadata are local, so substitution is a lookup there.
 
 **Server-side and client-side resolution apply the same map at the same
 point.** The flow above is client-side resolution: pnpm reads packuments,
@@ -795,6 +803,15 @@ Tests should cover, at minimum:
   (entries, compressed bytes) does the single cached document stop being the
   right delivery, and is the fallback a name-filtered bulk lookup, a
   chunked/delta encoding, or both?
+- **Client-side integrity as defense in depth.** The patched content
+  originates from the provider's infrastructure, and pnpr's serving-path
+  verification is what stands between a compromised patch source and
+  clients. Should the document optionally carry each entry's
+  manifest-pinned integrity as a *verification sidecar* — not part of
+  override semantics, so the mechanism does not fork — letting patch-aware
+  clients double-check substituted tarballs against the provider's signed
+  manifest even if pnpr's enforcement failed? Costs document size (hashes
+  do not compress) for a redundant check; deliberately undecided.
 - **Default mode.** Is `advertise` the right default for `patching:`, with
   `substitute` as the explicit escalation? (This RFC assumes yes: changing
   what fresh resolutions receive should be a deliberate, visible deployment

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -11,18 +11,20 @@ provider publishes patched artifacts under its own package namespace
 (`@echo-patch/ejs@2.7.4`), served through ordinary registries and routers. A
 signed, pinned **patch manifest** ties the two names together, and a
 per-registry `patching:` policy
-applies it in one of two modes. Both end in the same client primitive — a
-**post-pick substitution rule** applied by a patch-aware resolver **after
-version selection**: whenever resolution picks a covered version, it
-returns the provider's aliased artifact instead, recorded like an ordinary
-alias with a canonical, host-free lockfile resolution, while already-pinned
-installs are never altered. The modes differ in where the rule comes from:
-in **advertise** mode nothing substitutes by default — patches are
-discovered through audit enrichment and adopted as explicit
-workspace-stored rules (written by hand or by `pnpm audit --fix`); in
-**substitute** mode pnpr **annotates** the vulnerable version's packument
-entry and the resolver substitutes by default, with a per-package ignore
-list to refuse.
+applies it in one of two modes. Both end in the same client primitive — an
+**exact-version override applied to the picked version** (a small pnpm
+semantics fix, specified in the companion RFC): whenever resolution picks a
+covered version, the resolver returns the provider's aliased artifact
+instead, recorded like an ordinary alias with a canonical, host-free
+lockfile resolution, while already-pinned installs are never altered. The
+modes differ in where the override comes from: in **advertise** mode
+nothing substitutes by default — patches are discovered through audit
+enrichment and adopted as ordinary workspace overrides (written by hand or
+by `pnpm audit --fix`); in **substitute** mode pnpr **annotates** the
+vulnerable version's packument entry, which the resolver honors as a
+registry-supplied override at the lowest precedence — any workspace
+override claiming the same pick, including a self-mapping that keeps the
+original, wins.
 
 Notably, this requires **no new registry kind**. Both shapes are expressible
 with hosted/upstream/router registries as already specified; the only
@@ -237,11 +239,32 @@ package versions to their patched counterparts:
   because adoption is always an exact pin produced from the manifest — no
   range resolution against upstream expectations ever happens there.
 
-### Advertise mode: discovery and explicit acceptance
+### Advertise mode: discovery and explicit adoption
 
 In `advertise` mode the registry substitutes nothing and serves no
 annotations: adoption is an explicit, reviewable workspace decision, and
-discovery flows through the audit endpoint. Three adoption paths:
+discovery flows through the audit endpoint. Adoption is an **ordinary
+exact-version override**:
+
+```jsonc
+{
+  "pnpm": {
+    "overrides": {
+      "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"
+    }
+  }
+}
+```
+
+made effective by the companion pnpm RFC's semantics fix: an exact-version
+override selector also matches the **picked** version, so this override
+covers a dependency declared as `^2.7.0` the moment resolution picks
+`2.7.4` — not only exact-pinned declarations, as today's subset matching
+would. The fix also gives the override the right aging behavior: when
+upstream releases a fixed `2.7.5` and ranges pick it, the override goes
+inert instead of freezing the graph to the patch.
+
+Three adoption paths:
 
 1. **Audit enrichment.** pnpr implements the npm audit endpoints
    (`/-/npm/v1/security/advisories/bulk`) against OSV plus the pinned
@@ -250,32 +273,19 @@ discovery flows through the audit endpoint. Three adoption paths:
    "an aliased fix exists", so pnpr adds a namespaced extension field
    carrying the mapping (`ejs@2.7.4 → npm:@echo-patch/ejs@2.7.4`); clients
    that do not know the field ignore it.
-2. **Explicit acceptance (patch-aware clients).** The workspace stores
-   accepted substitutions in its config, each entry a self-contained
-   mapping (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`), and the
-   patch-aware resolver (see substitute mode) applies them **after version
-   selection**, exactly as it applies substitute-mode annotations — which
-   is what makes acceptance correct for picks reached through ranges, the
-   case overrides cannot express (below). `pnpm audit --fix` (pnpm
-   follow-up, out of scope here) becomes mechanical: copy the mappings from
-   the enriched audit response into config — reviewable in the PR that
-   introduces them, removable after upgrading away. A stored rule pins the
-   patch *revision*: when a provider re-issues (`-sp2`), the next
-   `pnpm audit` reports it and `--fix` updates the entry — an explicit,
-   reviewable update, in keeping with the mode.
-3. **Hand-written overrides (any npm-compatible client, today).** An alias
-   override adopts a patch with no new client feature — but overrides
-   rewrite *declared specs* by subset matching, and that has teeth:
-   `"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"` covers only dependencies
-   declared as exactly `2.7.4`, silently missing every `^2.7.0` that
-   resolves to `2.7.4`. Covering ranges requires keying by the declared
-   ranges themselves (`"ejs@^2.7.0": "npm:@echo-patch/ejs@2.7.4"`), which
-   *freezes* everything inside that range to the patched build — including
-   after upstream releases a fixed `2.7.5` — and misses differently-shaped
-   ranges added later; a bare-name key is the same trade graph-wide. This
-   path is honest and available, but it is a blunt instrument, not the
-   mechanism this RFC builds on — and it is why `pnpm audit --fix` writes
-   post-pick substitution rules rather than overrides.
+2. **`pnpm audit --fix`.** Mechanical: copy the mappings from the enriched
+   audit response into `overrides` — reviewable in the PR that introduces
+   them, removable after upgrading away. An override pins the patch
+   *revision*: when a provider re-issues (`-sp2`), the next `pnpm audit`
+   reports it and `--fix` updates the entry — an explicit, reviewable
+   update, in keeping with the mode.
+3. **Hand-written overrides on clients without the fix.** Under today's
+   subset-only semantics the exact-version key covers only exact-pinned
+   declarations; covering ranges takes a declared-range key
+   (`"ejs@^2.7.0": …`), which *freezes* that range to the patched build
+   even after a fixed `2.7.5` ships, or a bare-name key, the same trade
+   graph-wide. Honest, available, blunt — and the reason the companion fix
+   exists.
 
 What the alias buys over other encodings of "patched artifact":
 
@@ -293,7 +303,7 @@ What the alias buys over other encodings of "patched artifact":
   tooling — never see a prerelease identifier on the adoption path.
 
 Advertise mode's limit is deliberate: it is **opt-in per workspace**. A
-fresh `pnpm install` in a repository that has accepted nothing resolves
+fresh `pnpm install` in a repository that has adopted nothing resolves
 `^2.7.0` to the vulnerable original, exactly as before, and repositories
 that never run `pnpm audit` never find out. When the deployment's intent is
 "no fresh resolution may pick a version we have a patch for", that is
@@ -333,12 +343,12 @@ The annotation is applied **on egress**: the cached upstream packument stays
 byte-identical to what the origin served, and the annotation is layered on
 at response time as a pure function of the pinned manifest snapshot. The
 field is inert for any client that does not know it. To the patch-aware
-resolver, an annotation is simply a registry-supplied **post-pick
-substitution rule** — the same primitive a workspace stores explicitly in
-advertise mode — applied by default, with the workspace's ignore list as
-the refusal surface.
+resolver, an annotation is simply a **registry-supplied exact-version
+override** — the same primitive a workspace writes in advertise mode —
+merged at the lowest precedence: any workspace override claiming the same
+pick outranks it.
 
-A patch-aware resolver (a pnpm follow-up RFC) selects the annotation
+A patch-aware resolver (the companion pnpm RFC) selects the annotation
 *inside* the resolve call. pnpm's resolver already separates a dependency's
 **alias** — the key in the dependent's manifest — from the **resolved
 identity** it returns (`id`, `manifest`, `resolution`); that split is how
@@ -349,12 +359,8 @@ identity** it returns (`id`, `manifest`, `resolution`); that split is how
 alias `ejs`. Version selection is never changed — the pick is the key that
 selects the patch — only which *build* of the selected version is
 installed. A substituted result is returned as-is, never re-matched, so
-substitutions cannot chain. And no override semantics change anywhere:
-workspace overrides keep exactly their current meaning, applied to declared
-specs before resolution, and continue to apply here (an override that
-rewrites the spec away from `ejs@2.7.4` means that version is never picked
-and the annotation never consulted). Everything downstream is pnpm's
-already-shipped alias machinery, and that is the point:
+substitutions cannot chain. Everything downstream is pnpm's already-shipped
+alias and overrides machinery, and that is the point:
 
 - **The lockfile stays canonical and host-free.** A fresh resolution of
   `^2.7.0` picks `2.7.4`, the annotation redirects that pick, and the
@@ -367,24 +373,22 @@ already-shipped alias machinery, and that is the point:
   a resolution is made; an existing lockfile entry is never touched, and a
   `--frozen-lockfile` install reads no packuments at all. Substitute at
   resolution, never at fetch.
-- **Substitutions are recorded so the lockfile stays self-consistent.** To
-  pnpm's up-to-date check, `ejs: ^2.7.0` resolving to an alias it cannot
-  explain from the workspace's own config would look like an entry needing
-  re-resolution. The follow-up therefore records substituted entries
-  (mapping plus source registry) in a dedicated lockfile section — only
-  applied entries, so the lockfile grows with the workspace, not the
-  provider's catalog. The record lets satisfiability checks accept the
-  aliased entry, lets a withdrawn patch re-resolve exactly the affected
-  packages, and tells humans and SBOM tooling *why* the alias exists.
+- **No new lockfile machinery.** A workspace-adopted patch is an ordinary
+  override, recorded and change-detected by the lockfile's existing
+  overrides record. An annotation-produced alias persists like any locked
+  resolution — authoritative until an ordinary re-resolution event —
+  and whether the up-to-date check needs a minimal marker for entries it
+  cannot attribute to workspace config is an implementation question in the
+  companion RFC, not a new explanatory section.
 - **Provenance is legible and diffable.** The lockfile shows `ejs` resolving
-  to `@echo-patch/ejs@2.7.4` and the recorded entry that caused it; when a
-  manifest refresh moves a patch to `-sp2`, the next non-frozen resolution
-  produces a reviewable lockfile diff in both places.
-- **Opting out is an explicit client setting.** With no override merge
-  involved, precedence cannot express refusal; the companion pnpm RFC
-  defines an ignore list (per package, or per provider) that makes the
-  resolver skip the annotation — declared in workspace config, visible and
-  reviewable like an override.
+  to `@echo-patch/ejs@2.7.4`; when a manifest refresh moves a patch to
+  `-sp2`, the next non-frozen resolution produces a reviewable lockfile
+  diff.
+- **Opting out is ordinary override precedence.** A workspace that must
+  keep the vulnerable original writes a self-mapping override
+  (`"ejs@2.7.4": "npm:ejs@2.7.4"`), which claims the pick and outranks the
+  registry's annotation — visible and reviewable, in the vocabulary users
+  already know.
 
 **Client choice is not a security boundary.** Clients that are not
 patch-aware ignore the unknown field and resolve the vulnerable original —
@@ -393,9 +397,10 @@ substitute. Neither is a policy bypass, because the boundary a deployment
 can rely on is registry-side: with `enforcement: refuse`, the tarball route
 answers a manifest-covered vulnerable artifact with the explicit
 `403`-plus-suggested-patch body instead of bytes — for **every** client,
-patch-aware or not, opted out or not. Under `refuse`, an ignore-list entry
-can choose failure over substitution, but can never obtain the vulnerable
-bytes; client-side substitution is a protection and compatibility layer,
+patch-aware or not, opted out or not. Under `refuse`, a self-mapping
+override can choose failure over substitution, but can never obtain the
+vulnerable bytes; client-side substitution is a protection and compatibility
+layer,
 never the enforcement mechanism. `refuse` is hard enforcement, stated
 honestly: the tarball route cannot distinguish a fresh resolution from an
 old pinned one, so it also blocks existing lockfiles that pin the
@@ -564,13 +569,12 @@ instead of altering `dist`, only a resolver that understands it acts on it,
 and the result is recorded as a first-class aliased identity with a
 canonical, recomputable resolution.
 
-### Distributing the mapping as spec-rewriting overrides, unchanged
+### Relying on today's override semantics, unchanged
 
-The simplest client story would be serving the mapping *in overrides
-format* for clients to merge alongside workspace overrides, with no
-semantic change anywhere. Rejected because today's override semantics
-cannot express the goal. Overrides rewrite **declared specs** before
-resolution, and a selector matches a declared range by subset:
+The simplest client story would be adoption through overrides *as they
+behave today*, with no client change anywhere. Rejected because today's
+semantics cannot express the goal. Overrides rewrite **declared specs**
+before resolution, and a selector matches a declared range by subset:
 `"ejs@2.7.4"` applies to a dependency declared as `2.7.4`, but not to
 `^2.7.0` — whose resolution to `2.7.4` is exactly the case that needs
 protection. Widening the selector cannot fix it: no range selector matches
@@ -578,45 +582,35 @@ protection. Widening the selector cannot fix it: no range selector matches
 (`"ejs": "npm:@echo-patch/ejs@2.7.4"`) *changes version selection* — it
 forces every `ejs` in the graph to the patched `2.7.4`, downgrading a
 `^2.7.0` that would have picked a genuinely fixed `2.7.5`. Any correct
-mechanism must act after version selection — spec rewriting cannot see the
-pick. The same fact rules out `pnpm audit --fix` emitting overrides: an
-exact-version key would not apply to range declarations, and range or
-bare-name keys freeze or force version selection — which is why the fix
-flow writes post-pick substitution rules for the patch-aware resolver
-instead.
+mechanism must act after version selection — which is why the companion
+RFC's fix makes exact-version selectors match the picked version. The fix
+is deliberately framed as a *fix*: the newly covered cases are ones where
+the override silently did nothing, contrary to its author's evident
+intent.
 
-### A standalone patched-versions document plus an override extension
+### A separate substitution-rules config beside overrides
 
-The previous draft of substitute mode compiled the manifests into a
-standalone document at a well-known endpoint
-(`/-/pnpr/patched-versions`), applied by the client through a semantic
-extension of overrides: an override whose selector is an exact version
-would also match the *picked* version at resolution time, and the
-document's exact-version→alias entries would merge beneath the workspace's
-own overrides. It satisfies the act-after-selection requirement, and its
-opt-out story is elegant (workspace override precedence). The annotation
-was chosen over it because:
+An earlier draft avoided touching override semantics by giving the
+patch-aware resolver its own config surface: workspace-stored post-pick
+rules, plus accept/ignore lists governing registry annotations. Rejected
+as duplication: it is a second way to say "replace this package," with its
+own precedence rules, its own opt-out surface, and its own lockfile
+recording — all of which the override surface already provides once the
+exact-version fix lands. Workspace authority over registry annotations
+falls out of ordinary override precedence (a self-mapping override keeps
+the original), and `pnpm audit --fix` writes plain overrides instead of
+entries in a parallel system.
 
-- **Delivery and discovery.** A standalone catalog is a whole protocol
-  surface: endpoint path and discovery, trust/signing, machine-wide
-  caching and revalidation, size bounds and a scale escape hatch. The
-  annotation needs none of it — mappings arrive with exactly the
-  packuments being resolved, proportionally, over the already-authenticated
-  registry connection.
-- **No override-semantics change.** The extension was carefully additive
-  (for an exact-version selector, post-pick matching only covers picks that
-  previously slipped through), but it was still a behavior change to
-  existing workspace configs, with real questions about how it ships.
-  Resolver-side annotation selection leaves override semantics completely
-  untouched.
+### A standalone patched-versions document
 
-What the document did better is worth recording: workspace opt-out fell out
-of ordinary override precedence (annotations need an explicit ignore
-setting instead), and the override extension also empowered *hand-written*
-exact-version overrides to catch range-resolved picks — a genuinely useful
-capability that the annotation approach does not deliver. If that proves
-worth having, it can be proposed independently in pnpm; nothing in this
-design conflicts with it.
+Another earlier draft compiled the manifests into a standalone document at
+a well-known endpoint (`/-/pnpr/patched-versions`) for clients to fetch and
+merge. It satisfies the act-after-selection requirement, but a standalone
+catalog is a whole protocol surface: endpoint path and discovery,
+trust/signing, machine-wide caching and revalidation, size bounds and a
+scale escape hatch. The annotation needs none of it — mappings arrive with
+exactly the packuments being resolved, proportionally, over the
+already-authenticated registry connection.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -688,10 +682,10 @@ layered over pristine cached packuments:
    substitution marker, and include the patching policy and snapshot digest
    in resolution-cache keys.
 
-The client side — the patch-aware resolver applying post-pick substitution
-rules from two sources (workspace-stored mappings, and `_pnprPatch`
-annotations filtered by the ignore list), the lockfile record, and
-`pnpm audit --fix` — is specified in the companion pnpm RFC,
+The client side — the exact-version override fix (selectors match the
+picked version), annotations honored as registry-supplied overrides at the
+lowest precedence, and `pnpm audit --fix` writing ordinary overrides — is
+specified in the companion pnpm RFC,
 [`text/0000-post-pick-substitution.md`](../../text/0000-post-pick-substitution.md),
 submitted alongside this one.
 
@@ -840,20 +834,18 @@ Tests should cover, at minimum:
   overrides once the pnpm lockfile registry-identity follow-up lands; the
   annotation could then carry a registry-qualified spec as an alternative
   encoding.
-- **Patch-aware resolver design.** The pnpm-side follow-up must settle
+- **Patch-aware resolver design.** The companion pnpm RFC must settle
   whether annotations are honored by default when present or behind a
   setting, whether they are honored from *any* registry or only from
-  configured pnpr bases, the config shape of workspace substitution rules
-  and of the ignore list (per package or per provider), how provenance is
-  surfaced (`pnpm why`, install summary, the `resolvedVia` marker), and the
-  annotation field name (`_pnprPatch` vs. something vendor-neutral other
-  resolvers could adopt).
-- **Lockfile recording shape.** The name and format of the lockfile section
-  recording substituted entries — it must let satisfiability checks accept
-  an aliased resolution the workspace's own config does not explain, and
-  distinguish it from a hand-written override — and the adoption-timing
-  default: is silently adopting a newly published patch for an
-  already-locked pick on the next non-frozen re-resolution the right
+  configured pnpr bases, how provenance is surfaced (`pnpm why`, install
+  summary, the `resolvedVia` marker), and the annotation field name
+  (`_pnprPatch` vs. something vendor-neutral other resolvers could adopt).
+- **Up-to-date semantics and adoption timing.** Whether pnpm's up-to-date
+  check needs a minimal marker for annotation-produced aliases it cannot
+  attribute to workspace config (workspace-adopted patches are ordinary
+  overrides, covered by the existing overrides record), and the
+  adoption-timing default: is silently adopting a newly published patch for
+  an already-locked pick on the next non-frozen re-resolution the right
   behavior, or should new adoptions require an explicit gesture
   (`pnpm update --patches`-style) while only *withdrawn* patches act
   automatically?

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -325,23 +325,24 @@ mounts:
       minSeverity: high      # only include fixes at/above this severity
 ```
 
-A patch-aware client applies the document **after version selection** —
-deliberately *not* as a spec-rewriting override. Today's overrides rewrite
-declared specs and match them by subset, so an exact-version key like
-`ejs@2.7.4` would never apply to a dependency declared as `^2.7.0` — and
-`^2.7.0` picking `2.7.4` is exactly the fresh-resolution case substitute mode
-exists for. The proposed client mechanism (a pnpm follow-up RFC) is a second
-override kind, **resolution overrides**: selectors matched against the
-**picked** version after the resolver has chosen it, replacing that pick with
-the target spec. Matching a concrete version is *simpler* than today's
-subset-against-declared-range semantics (`semver.satisfies(picked, selector)`),
-the substitution is applied exactly once (a substituted target is not
-re-matched, so maps cannot chain or cycle), and workspaces can declare
-resolution overrides of their own — the registry-provided document is merged
-beneath them as the lowest-precedence source. Version selection is never
-changed — only which *build* of the selected version is installed.
-Everything downstream is pnpm's already-shipped alias machinery, and that is
-the point:
+A patch-aware client applies the document **after version selection** as
+well. The proposed client mechanism (a pnpm follow-up RFC) is not a new
+override kind but a semantic extension of the existing one: **an override
+whose selector is an exact version also matches the *picked* version at
+resolution time.** Today such an override rewrites only declared specs, by
+subset — and the only range that is a subset of `2.7.4` is `2.7.4` itself,
+so a dependency declared as `^2.7.0` slips past it even when resolution
+picks `2.7.4`. The extension is therefore strictly additive: every case the
+spec rewrite already handles produces the identical result post-pick, and
+the new behavior covers exactly the picks that previously slipped through —
+which is what the override's author meant all along. The substitution is
+applied exactly once (a substituted target is not re-matched, so maps
+cannot chain or cycle). Because the document's entries are all
+exact-version→exact-spec, they are ordinary overrides under this extension,
+and the registry document is merged beneath the workspace's own overrides
+as the lowest-precedence source. Version selection is never changed — only
+which *build* of the selected version is installed. Everything downstream
+is pnpm's already-shipped alias machinery, and that is the point:
 
 - **The lockfile stays canonical and host-free.** A fresh resolution of
   `^2.7.0` picks `2.7.4`, the document redirects that pick, and the lockfile
@@ -357,10 +358,9 @@ the point:
   to `@echo-patch/ejs@2.7.4`; when a manifest refresh moves a patch to
   `-sp2`, the next non-frozen resolution produces a reviewable lockfile diff.
 - **Opting out is ordinary precedence.** A workspace that must keep a
-  vulnerable original declares its own resolution override for
-  `ejs@2.7.4` (mapping the pick to itself), which outranks the
-  registry-provided document — visible and reviewable, like every other
-  override.
+  vulnerable original declares its own override for `ejs@2.7.4` (mapping the
+  pick to itself), which outranks the registry-provided document — visible
+  and reviewable, like every other override.
 
 Clients that are not patch-aware never ask for the document and resolve the
 vulnerable original — no worse than today. Per-mount policy can escalate:
@@ -519,25 +519,30 @@ The registry-provided document subsumes both: the same information, one
 document beside the registry surface, zero changes to packument or tarball
 serving, and one client-side application point after version selection.
 
-### Applying the document as spec-rewriting overrides
+### Applying the document under today's override semantics, unchanged
 
 An earlier draft served the document *in overrides format* for the client to
-merge alongside workspace overrides. Rejected because the semantics do not
-line up. Overrides rewrite **declared specs** before resolution, and a
-selector matches a declared range by subset: `"ejs@2.7.4"` applies to a
-dependency declared as `2.7.4`, but not to `^2.7.0` — whose resolution to
-`2.7.4` is exactly the case that needs protection. Widening the selector
-cannot fix it: no range selector matches `^2.7.0` short of the bare name,
-and a bare-name override (`"ejs": "npm:@echo-patch/ejs@2.7.4"`) *changes
-version selection* — it forces every `ejs` in the graph to the patched
-`2.7.4`, downgrading a `^2.7.0` that would have picked a genuinely fixed
-`2.7.5`. Post-pick substitution has neither problem: the resolver picks
-whatever it would have picked, and only a picked version with a patch is
-swapped for its patched build of the *same* version. That is why the client
-mechanism is proposed as a second override kind matched after resolution —
-**resolution overrides** — rather than a reuse of spec rewriting: overrides
-stay the answer, applied at the stage where the question can actually be
-asked.
+merge alongside workspace overrides, with no semantic change. Rejected
+because today's semantics cannot express the goal. Overrides rewrite
+**declared specs** before resolution, and a selector matches a declared
+range by subset: `"ejs@2.7.4"` applies to a dependency declared as `2.7.4`,
+but not to `^2.7.0` — whose resolution to `2.7.4` is exactly the case that
+needs protection. Widening the selector cannot fix it: no range selector
+matches `^2.7.0` short of the bare name, and a bare-name override
+(`"ejs": "npm:@echo-patch/ejs@2.7.4"`) *changes version selection* — it
+forces every `ejs` in the graph to the patched `2.7.4`, downgrading a
+`^2.7.0` that would have picked a genuinely fixed `2.7.5`.
+
+The fix is the exact-version extension described in substitute mode, chosen
+over a *separate* post-resolution override kind because for exact-version
+selectors the two application points agree wherever both apply — the only
+subset of `2.7.4` is `2.7.4` itself — so post-pick matching is a strict
+widening of the same override, not a competing mechanism with its own
+precedence rules. The extension deliberately stops at exact selectors:
+applying a *range* selector to picked versions with a range replacement
+would re-open version selection after the resolver closed it and would
+silently reinterpret existing workspace configs, whereas the exact-selector
+case only starts covering picks that previously slipped through.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -601,10 +606,11 @@ mount graph, routing, or the packument/tarball serving paths:
    the tarball route with the `403` reason body.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
-overrides from the enriched audit response, and the **resolution overrides**
-extension — override selectors matched against the picked version, applied
-exactly once, with workspace-declared entries outranking the
-registry-provided patched-versions document.
+overrides from the enriched audit response, and the exact-version override
+extension — an override whose selector is an exact version also matches the
+picked version at resolution time, applied exactly once, with the
+workspace's own overrides outranking the registry-provided patched-versions
+document.
 
 Tests should cover, at minimum:
 
@@ -704,14 +710,17 @@ Tests should cover, at minimum:
   over the authenticated registry connection, and how a client maps multiple
   configured registries to multiple documents (fetch from each base? default
   registry only?).
-- **Resolution-overrides design.** The pnpm-side follow-up must settle the
-  syntax (a separate field vs. an extension of the existing `overrides`
-  block), whether a registry-provided document is applied by default or
-  behind a setting, how provenance is surfaced (`pnpm why`, install
-  summary), the exact once-only application rule for substituted targets,
-  and how an existing lockfile interacts with a changed document —
-  re-resolve only on ordinary re-resolution events, or also when the
-  document digest changes? The answers shape the document format.
+- **Exact-version override extension design.** The pnpm-side follow-up must
+  settle how the semantic extension ships (silently, behind a setting, or in
+  a major release — existing configs with exact-version selectors start
+  covering picks they previously missed, which is intended but is a
+  behavior change), whether a registry-provided document is applied by
+  default or behind a setting, how provenance is surfaced (`pnpm why`,
+  install summary), the exact once-only application rule for substituted
+  targets, whether parent-scoped selectors (`a>b@1.0.0`) participate, and
+  how an existing lockfile interacts with a changed document — re-resolve
+  only on ordinary re-resolution events, or also when the document digest
+  changes? The answers shape the document format.
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the
   right delivery, and is the fallback a name-filtered bulk lookup, a

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -385,6 +385,23 @@ route cannot distinguish a fresh resolution from an old pinned one, so
 which is precisely what "no known-patchable vulnerable artifact leaves this
 registry" means. The default is `serve`.
 
+**Resolution cost.** Matching is a map lookup per pick — free for the
+unpatched majority. A matched pick triggers resolving the alias target: an
+exact-version resolution against the patch-scope packument. That is a second
+resolution of *that dependency*, never of the graph, and the original pick
+is not wasted work — it is the key that selects the patch, and there is no
+way to learn that `^2.7.0` lands on `2.7.4` without performing the pick. The
+marginal cost over a hand-written alias override is therefore one extra
+packument fetch per patched package, against a packument that is small
+(patched versions only) and cached like any other. Even that fetch is
+optimizable to zero: the document derives from a manifest that already pins
+the patched tarball's integrity, so entries can optionally carry it — the
+canonical tarball URL is computable from registry config, letting the client
+construct the substituted resolution with no additional metadata request and
+read the manifest for subtree resolution from the tarball it will fetch
+regardless. Server-side, the map and the patch-scope metadata are local, so
+substitution is a lookup.
+
 **Server-side and client-side resolution apply the same map at the same
 point.** The flow above is client-side resolution: pnpm reads packuments,
 picks versions locally, and consults its cached copy of the document
@@ -771,6 +788,10 @@ Tests should cover, at minimum:
   (entries, compressed bytes) does the single cached document stop being the
   right delivery, and is the fallback a name-filtered bulk lookup, a
   chunked/delta encoding, or both?
+- **Document fast-path fields.** Should entries carry the patched artifact's
+  integrity (and possibly manifest essentials) so a client can construct the
+  substituted resolution without fetching the patch-scope packument — a
+  fatter document traded for zero extra metadata requests per substitution?
 - **Default mode.** Is `advertise` the right default for `patching:`, with
   `substitute` as the explicit escalation? (This RFC assumes yes: changing
   what fresh resolutions receive should be a deliberate, visible deployment

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -10,17 +10,18 @@ vendor is the declared origin), and a **patch scope** — the provider publishes
 patched artifacts under its own package namespace (`@echo-patch/ejs@2.7.4`),
 served through ordinary mounts and routes. A signed, pinned **patch
 manifest** ties the two names together, and a per-mount `patching:` policy
-applies it in one of two modes. Both serve the same per-version
-**annotation** on the vulnerable version's packument entry, which a
-patch-aware resolver acts on **after version selection**: whenever
-resolution picks an annotated version, it returns the provider's aliased
-artifact instead — recorded like an ordinary alias, with a canonical,
-host-free lockfile resolution — while already-pinned installs are never
-altered. The modes differ only in the client posture the annotation
-requests: **advertise** substitutes only for patches the workspace has
-explicitly accepted (discovered through audit enrichment, accepted by hand
-or via `pnpm audit --fix`), while **substitute** substitutes by default,
-with a per-package ignore list to refuse.
+applies it in one of two modes. Both end in the same client primitive — a
+**post-pick substitution rule** applied by a patch-aware resolver **after
+version selection**: whenever resolution picks a covered version, it
+returns the provider's aliased artifact instead, recorded like an ordinary
+alias with a canonical, host-free lockfile resolution, while already-pinned
+installs are never altered. The modes differ in where the rule comes from:
+in **advertise** mode nothing substitutes by default — patches are
+discovered through audit enrichment and adopted as explicit
+workspace-stored rules (written by hand or by `pnpm audit --fix`); in
+**substitute** mode pnpr **annotates** the vulnerable version's packument
+entry and the resolver substitutes by default, with a per-package ignore
+list to refuse.
 
 Notably, this requires **no new mount kind**. Both shapes are expressible
 with hosted/upstream/router mounts as already specified; the only
@@ -230,11 +231,9 @@ package versions to their patched counterparts:
 
 ### Advertise mode: discovery and explicit acceptance
 
-In `advertise` mode the registry surfaces available patches but substitutes
-nothing by default: adoption is an explicit, reviewable workspace decision.
-The mechanics are the same annotation and patch-aware resolver as substitute
-mode (below) — the annotation simply requests an **opt-in posture**. Three
-adoption paths:
+In `advertise` mode the registry substitutes nothing and serves no
+annotations: adoption is an explicit, reviewable workspace decision, and
+discovery flows through the audit endpoint. Three adoption paths:
 
 1. **Audit enrichment.** pnpr implements the npm audit endpoints
    (`/-/npm/v1/security/advisories/bulk`) against OSV plus the pinned
@@ -243,15 +242,19 @@ adoption paths:
    "an aliased fix exists", so pnpr adds a namespaced extension field
    carrying the mapping (`ejs@2.7.4 → npm:@echo-patch/ejs@2.7.4`); clients
    that do not know the field ignore it.
-2. **Explicit acceptance (patch-aware clients).** The workspace lists
-   accepted patches in its config — per entry, or per provider — and the
-   patch-aware resolver substitutes exactly as in substitute mode, but only
-   for accepted entries. `pnpm audit --fix` (pnpm follow-up, out of scope
-   here) becomes mechanical: read the enriched audit response, append
-   accept-list entries — reviewable in the PR that introduces them,
-   removable after upgrading away. Because acceptance is applied by the
-   resolver **after version selection**, it correctly covers picks reached
-   through ranges — the case overrides cannot express, below.
+2. **Explicit acceptance (patch-aware clients).** The workspace stores
+   accepted substitutions in its config, each entry a self-contained
+   mapping (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`), and the
+   patch-aware resolver (see substitute mode) applies them **after version
+   selection**, exactly as it applies substitute-mode annotations — which
+   is what makes acceptance correct for picks reached through ranges, the
+   case overrides cannot express (below). `pnpm audit --fix` (pnpm
+   follow-up, out of scope here) becomes mechanical: copy the mappings from
+   the enriched audit response into config — reviewable in the PR that
+   introduces them, removable after upgrading away. A stored rule pins the
+   patch *revision*: when a provider re-issues (`-sp2`), the next
+   `pnpm audit` reports it and `--fix` updates the entry — an explicit,
+   reviewable update, in keeping with the mode.
 3. **Hand-written overrides (any npm-compatible client, today).** An alias
    override adopts a patch with no new client feature — but overrides
    rewrite *declared specs* by subset matching, and that has teeth:
@@ -264,7 +267,7 @@ adoption paths:
    ranges added later; a bare-name key is the same trade graph-wide. This
    path is honest and available, but it is a blunt instrument, not the
    mechanism this RFC builds on — and it is why `pnpm audit --fix` writes
-   accept-list entries rather than overrides.
+   post-pick substitution rules rather than overrides.
 
 What the alias buys over other encodings of "patched artifact":
 
@@ -290,11 +293,10 @@ substitute mode.
 
 ### Substitute mode: annotated packuments selected by the resolver
 
-Both modes put the mapping where the resolver is already looking: on the
-vulnerable version's entry in the packument. For every manifest entry the
-mount's policy accepts, pnpr serves the base packument with an annotation on
-that version — original metadata and `dist` untouched — carrying the mode's
-requested posture:
+`substitute` mode puts the mapping where the resolver is already looking:
+on the vulnerable version's entry in the packument. For every manifest
+entry the mount's policy accepts, pnpr serves the base packument with an
+annotation on that version — original metadata and `dist` untouched:
 
 ```jsonc
 // GET /~main/ejs — versions["2.7.4"], annotated on egress
@@ -303,8 +305,7 @@ requested posture:
   "_pnprPatch": {
     "patched": "npm:@echo-patch/ejs@2.7.4",
     "provider": "echo",
-    "fixes": ["GHSA-..."],
-    "apply": "default"        // advertise mode serves "opt-in"
+    "fixes": ["GHSA-..."]
   }
 }
 ```
@@ -327,11 +328,11 @@ mounts:
 The annotation is applied **on egress**: the cached upstream packument stays
 byte-identical to what the origin served, and the annotation is layered on
 at response time as a pure function of the pinned manifest snapshot. The
-field is inert for any client that does not know it. In advertise mode the
-identical annotation is served with `apply: opt-in` and the resolver
-substitutes only workspace-accepted entries (previous section); the rest of
-this section describes the default-on posture that gives substitute mode its
-name.
+field is inert for any client that does not know it. To the patch-aware
+resolver, an annotation is simply a registry-supplied **post-pick
+substitution rule** — the same primitive a workspace stores explicitly in
+advertise mode — applied by default, with the workspace's ignore list as
+the refusal surface.
 
 A patch-aware resolver (a pnpm follow-up RFC) selects the annotation
 *inside* the resolve call. pnpm's resolver already separates a dependency's
@@ -376,20 +377,27 @@ already-shipped alias machinery, and that is the point:
   manifest refresh moves a patch to `-sp2`, the next non-frozen resolution
   produces a reviewable lockfile diff in both places.
 - **Opting out is an explicit client setting.** With no override merge
-  involved, precedence cannot express refusal; the follow-up defines an
-  ignore list (per package, or per provider) that makes the resolver skip
-  the annotation — declared in workspace config, visible and reviewable
-  like an override.
+  involved, precedence cannot express refusal; the companion pnpm RFC
+  defines an ignore list (per package, or per provider) that makes the
+  resolver skip the annotation — declared in workspace config, visible and
+  reviewable like an override.
 
-Clients that are not patch-aware ignore the unknown field and resolve the
-vulnerable original — no worse than today. Per-mount policy can escalate:
-`unawareClients: refuse` makes the tarball route answer a manifest-covered
-vulnerable artifact with the explicit `403`-plus-suggested-override body
-instead of bytes. That is hard enforcement, stated honestly: the tarball
-route cannot distinguish a fresh resolution from an old pinned one, so
-`refuse` also blocks existing lockfiles that pin the vulnerable original —
-which is precisely what "no known-patchable vulnerable artifact leaves this
-registry" means. The default is `serve`.
+**Client choice is not a security boundary.** Clients that are not
+patch-aware ignore the unknown field and resolve the vulnerable original —
+no worse than today — and patch-aware clients can be configured not to
+substitute. Neither is a policy bypass, because the boundary a deployment
+can rely on is registry-side: with `enforcement: refuse`, the tarball route
+answers a manifest-covered vulnerable artifact with the explicit
+`403`-plus-suggested-patch body instead of bytes — for **every** client,
+patch-aware or not, opted out or not. Under `refuse`, an ignore-list entry
+can choose failure over substitution, but can never obtain the vulnerable
+bytes; client-side substitution is a protection and compatibility layer,
+never the enforcement mechanism. `refuse` is hard enforcement, stated
+honestly: the tarball route cannot distinguish a fresh resolution from an
+old pinned one, so it also blocks existing lockfiles that pin the
+vulnerable original — which is precisely what "no known-patchable
+vulnerable artifact leaves this registry" means. The default is
+`enforcement: serve`.
 
 **Resolution cost.** Discovering patches costs nothing: the mapping rides
 the packument the resolver already fetched, so unpatched packages — and
@@ -570,7 +578,8 @@ mechanism must act after version selection — spec rewriting cannot see the
 pick. The same fact rules out `pnpm audit --fix` emitting overrides: an
 exact-version key would not apply to range declarations, and range or
 bare-name keys freeze or force version selection — which is why the fix
-flow writes accept-list entries for the patch-aware resolver instead.
+flow writes post-pick substitution rules for the patch-aware resolver
+instead.
 
 ### A standalone patched-versions document plus an override extension
 
@@ -660,13 +669,12 @@ pristine cached packuments:
    suggested override spec when a pinned manifest covers a vulnerable
    version.
 4. **Per-mount `patching:` policy and the egress annotation.** Validate the
-   policy block (known provider, mode, severity gate, `unawareClients`, one
-   substituting provider per original `name@version` per mount); annotate
-   matched version entries of served packuments on egress with the mode's
-   requested posture (`apply: default` / `opt-in`), as a pure function of
-   the pinned snapshots, leaving cached upstream documents and every `dist`
-   object untouched; implement `unawareClients: refuse` on the tarball
-   route with the `403` reason body.
+   policy block (known provider, mode, severity gate, `enforcement`, one
+   substituting provider per original `name@version` per mount); in
+   substitute mode, annotate matched version entries of served packuments
+   on egress as a pure function of the pinned snapshots, leaving cached
+   upstream documents and every `dist` object untouched; implement
+   `enforcement: refuse` on the tarball route with the `403` reason body.
 5. **Server-side resolution integration.** Where pnpr resolves on the
    client's behalf (the resolution endpoint of the auth-aware
    resolution-cache design), apply the same annotation logic inside
@@ -674,13 +682,12 @@ pristine cached packuments:
    substitution marker, and include the patching policy and snapshot digest
    in resolution-cache keys.
 
-Client-side follow-ups (separate pnpm RFC): the patch-aware resolver —
-selecting `_pnprPatch` inside the resolve call, returning the aliased
-identity (`resolvedVia: registry-patch`), recording substituted entries in
-a dedicated lockfile section so satisfiability checks accept them, and
-honoring the posture through accept lists (opt-in annotations) and ignore
-lists (default annotations) — plus `pnpm audit --fix` writing accept-list
-entries from the enriched audit response.
+The client side — the patch-aware resolver applying post-pick substitution
+rules from two sources (workspace-stored mappings, and `_pnprPatch`
+annotations filtered by the ignore list), the lockfile record, and
+`pnpm audit --fix` — is specified in the companion pnpm RFC,
+[`text/0000-post-pick-substitution.md`](../../text/0000-post-pick-substitution.md),
+submitted alongside this one.
 
 Tests should cover, at minimum:
 
@@ -697,20 +704,19 @@ Tests should cover, at minimum:
   patch against the same base version;
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
-- matched version entries annotated on egress only for manifest-covered,
-  policy-accepted versions, as a pure function of the pinned snapshot,
-  carrying `apply: opt-in` in advertise mode and `apply: default` in
-  substitute mode;
+- matched version entries annotated on egress only in substitute mode, only
+  for manifest-covered, policy-accepted versions, as a pure function of the
+  pinned snapshot — and no annotations served in advertise mode;
 - cached upstream packuments staying byte-identical to origin (annotation
   on egress only), every `dist` object and all tarball responses identical
   with `patching:` enabled and disabled;
 - the patch-scope packument's `dist.integrity` for a manifest-listed version
   equaling the manifest's pinned integrity (the client-visible pin);
 - an existing lockfile pinning the vulnerable original installing unchanged
-  through a substitute-mode mount (with `unawareClients: serve`);
-- `unawareClients: refuse` answering manifest-covered vulnerable tarballs
-  with `403` plus the suggested override, and leaving uncovered artifacts
-  untouched;
+  through a substitute-mode mount (with `enforcement: serve`);
+- `enforcement: refuse` answering manifest-covered vulnerable tarballs with
+  `403` plus the suggested patch for every caller, and leaving uncovered
+  artifacts untouched;
 - the one-substituting-provider-per-original rule enforced at config load;
 - server-side resolution returning aliased resolutions from the same pinned
   snapshot as the served annotations, and a manifest refresh re-keying
@@ -829,9 +835,8 @@ Tests should cover, at minimum:
 - **Patch-aware resolver design.** The pnpm-side follow-up must settle
   whether annotations are honored by default when present or behind a
   setting, whether they are honored from *any* registry or only from
-  configured pnpr bases, the shape of the opt-in and opt-out surfaces
-  (accept list for `apply: opt-in` annotations, ignore list for
-  `apply: default` ones — per package or per provider), how provenance is
+  configured pnpr bases, the config shape of workspace substitution rules
+  and of the ignore list (per package or per provider), how provenance is
   surfaced (`pnpm why`, install summary, the `resolvedVia` marker), and the
   annotation field name (`_pnprPatch` vs. something vendor-neutral other
   resolvers could adopt).

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -375,6 +375,23 @@ endpoint still reports the mapping, so a workspace can see which of its
 resolutions came from the registry's overrides and pin them explicitly if it
 prefers.
 
+**Document size.** The document grows linearly with the provider's patch
+catalog, and that catalog is advisory-driven: an entry exists only for an
+exact `name@version` that has a backported fix, so growth tracks CVE history
+in patched packages, not the registry. Realistic catalogs are on the order of
+10³–10⁴ entries; at roughly 80 bytes per entry that is sub-megabyte raw, and
+the shape (one scope prefix, repeated names) compresses to tens of kilobytes.
+Policy filtering (`minSeverity`, `requireAdvisoryMatch`) trims it further.
+Delivery cost is bounded by the caching contract rather than the size: the
+document changes only on manifest refresh or config reload, so a client
+caches it machine-wide per registry base (shared across workspaces, like the
+store) and revalidates with `If-None-Match` — the steady-state cost of
+substitute mode is one `304` per resolution run. Should a catalog ever
+outgrow single-document delivery, the escape hatch is a filtered bulk lookup
+shaped like the audit bulk endpoint (the client posts the names it is
+resolving); that variant is deliberately out of scope until real catalog
+sizes demand it.
+
 ### Advisory screening of patched artifacts
 
 Aliasing moves the advisory problem rather than removing it, and the manifest
@@ -642,6 +659,10 @@ Tests should cover, at minimum:
   setting? How is its provenance surfaced (`pnpm why`, lockfile comment,
   install summary)? These belong in the pnpm follow-up RFC, but the answers
   shape the document format.
+- **Scale threshold for a filtered variant.** At what measured catalog size
+  (entries, compressed bytes) does the single cached document stop being the
+  right delivery, and is the fallback a name-filtered bulk lookup, a
+  chunked/delta encoding, or both?
 - **Default mode.** Is `advertise` the right default for `patching:`, with
   `substitute` as the explicit escalation? (This RFC assumes yes: changing
   what fresh resolutions receive should be a deliberate, visible deployment

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -296,8 +296,7 @@ Advertise mode's audit enrichment already computes, per vulnerable version,
 the substitution a workspace should adopt. `substitute` mode serves that
 same result wholesale: the registry compiles the pinned, policy-filtered
 manifests into one **patched-versions document** — a flat map from exact
-original versions to alias specs, each carrying the manifest-pinned
-integrity of the patched tarball — at a well-known endpoint on each registry
+original versions to alias specs — at a well-known endpoint on each registry
 base that enables it:
 
 ```jsonc
@@ -305,14 +304,8 @@ base that enables it:
 {
   "schema": "pnpr-patched-versions/1",
   "versions": {
-    "ejs@2.7.4": {
-      "spec": "npm:@echo-patch/ejs@2.7.4",
-      "integrity": "sha512-..."
-    },
-    "lodash@4.17.20": {
-      "spec": "npm:@echo-patch/lodash@4.17.20",
-      "integrity": "sha512-..."
-    }
+    "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4",
+    "lodash@4.17.20": "npm:@echo-patch/lodash@4.17.20"
   }
 }
 ```
@@ -345,12 +338,12 @@ the new behavior covers exactly the picks that previously slipped through —
 which is what the override's author meant all along. The substitution is
 applied exactly once (a substituted target is not re-matched, so maps
 cannot chain or cycle). Because the document's entries are all
-exact-version→exact-spec, they are ordinary overrides under this extension
-— each with a pinned integrity riding along, the way a lockfile pins one —
-and the registry document is merged beneath the workspace's own overrides
-as the lowest-precedence source. Version selection is never changed — only
-which *build* of the selected version is installed. Everything downstream
-is pnpm's already-shipped alias machinery, and that is the point:
+exact-version→exact-spec, they are ordinary overrides under this extension,
+indistinguishable from ones the workspace wrote itself, and the registry
+document is merged beneath the workspace's own overrides as the
+lowest-precedence source. Version selection is never changed — only which
+*build* of the selected version is installed. Everything downstream is
+pnpm's already-shipped alias machinery, and that is the point:
 
 - **The lockfile stays canonical and host-free.** A fresh resolution of
   `^2.7.0` picks `2.7.4`, the document redirects that pick, and the lockfile
@@ -393,23 +386,25 @@ route cannot distinguish a fresh resolution from an old pinned one, so
 which is precisely what "no known-patchable vulnerable artifact leaves this
 registry" means. The default is `serve`.
 
-**Resolution cost: substitution is free by construction.** Matching is a
-map lookup per pick — nothing for the unpatched majority. A matched pick
-does not trigger a second metadata resolution either, because the entry
-carries everything a registry resolution consists of: the exact
-name-and-version (from `spec`) and the tarball integrity (from
-`integrity`), with the canonical tarball URL computable from registry
-config. The client constructs the substituted resolution directly — no
-patch-scope packument fetch — and reads the manifest for subtree resolution
-from the tarball it will fetch regardless. The original pick is not wasted
-work: it is the key that selects the patch, and there is no way to learn
-that `^2.7.0` lands on `2.7.4` without performing the pick. Carrying the
-integrity is also a provenance property, not only a shortcut: the
-substituted tarball is verified against the manifest-pinned digest the same
-way a locked resolution is, so a compromised patch source cannot serve
-different bytes than the provider's signed manifest promised — on the very
-first install, before any lockfile exists. Server-side, the map and the
-patch-scope metadata are local, so substitution is a lookup there too.
+**Resolution cost.** Matching is a map lookup per pick — nothing for the
+unpatched majority. A matched pick resolves the alias target: an
+exact-version resolution against the patch-scope packument, which is small
+(patched versions only), cached like any other, and fetched in parallel
+with the rest of resolution. That is a second resolution of *that
+dependency*, never of the graph, and the original pick is not wasted work —
+it is the key that selects the patch; there is no way to learn that
+`^2.7.0` lands on `2.7.4` without performing the pick. A fetch-free variant
+— carrying each patched tarball's integrity in the document so the client
+constructs the resolution directly — was considered and rejected: a
+hand-written override will never carry an integrity, so the mechanism would
+fork into two systems (or grow an object-form override type), and it
+crosses no trust boundary, because the document and the patch-scope
+packument are served by the same registry origin — pinning one to the other
+adds nothing a compromised registry could not rewrite in both. The
+end-to-end pin lives where it belongs: pnpr verifies patch-source bytes
+against the provider's *signed manifest* before serving them. Server-side,
+the map and the patch-scope metadata are local, so substitution is a lookup
+there.
 
 **Server-side and client-side resolution apply the same map at the same
 point.** The flow above is client-side resolution: pnpm reads packuments,
@@ -433,9 +428,9 @@ Costs and requirements, stated honestly:
 - **Automatic protection reaches only patch-aware clients.** npm and yarn
   users get advertise-mode discovery (and `refuse`, where enabled). pnpr is
   pnpm-first, and the document format is deliberately trivial — exact
-  version in; alias spec and integrity out — so other tools can consume it,
-  and an org can still mechanically derive blunt bare-name overrides from it
-  for clients that predate the feature.
+  version in, alias spec out — so other tools can consume it, and an org can
+  still mechanically derive blunt bare-name overrides from it for clients
+  that predate the feature.
 - **Provider retention becomes load-bearing.** A lockfile aliasing
   `@echo-patch/ejs@2.7.4` installs only while that artifact remains
   available. Providers must treat their patch namespaces as immutable and
@@ -463,9 +458,9 @@ prefers.
 catalog, and that catalog is advisory-driven: an entry exists only for an
 exact `name@version` that has a backported fix, so growth tracks CVE history
 in patched packages, not the registry. Realistic catalogs are on the order
-of 10³–10⁴ entries; at roughly 200 bytes per entry — the sha512 integrity
-dominates, and hash bytes do not compress — that is a couple of megabytes
-raw and on the order of a megabyte on the wire at the high end.
+of 10³–10⁴ entries; at roughly 80 bytes per entry that is sub-megabyte raw,
+and the shape (one scope prefix, repeated names) compresses to tens of
+kilobytes.
 Policy filtering (`minSeverity`, `requireAdvisoryMatch`) trims it further.
 Delivery cost is bounded by the caching contract rather than the size: the
 document changes only on manifest refresh or config reload, so a client
@@ -658,10 +653,9 @@ mount graph, routing, or the packument/tarball serving paths:
    Validate the policy block (known provider, mode, severity gate,
    `unawareClients`, one substituting provider per original `name@version`
    per mount); compile the pinned, policy-filtered manifests into the
-   `/-/pnpr/patched-versions` document — each entry carrying the
-   manifest-pinned integrity of its patched tarball — with a digest/ETag,
-   recompiled only on manifest refresh or config reload; implement
-   `unawareClients: refuse` on the tarball route with the `403` reason body.
+   `/-/pnpr/patched-versions` document with a digest/ETag, recompiled only
+   on manifest refresh or config reload; implement `unawareClients: refuse`
+   on the tarball route with the `403` reason body.
 5. **Server-side resolution integration.** Where pnpr resolves on the
    client's behalf (the resolution endpoint of the auth-aware
    resolution-cache design), apply the pinned map post-pick before a
@@ -692,8 +686,9 @@ Tests should cover, at minimum:
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
 - the patched-versions document compiled from pinned manifests, filtered by
-  `minSeverity`, stable between refreshes, served with a digest/ETag, and
-  carrying per-entry integrity equal to the manifest's;
+  `minSeverity`, stable between refreshes, and served with a digest/ETag;
+- the patch-scope packument's `dist.integrity` for a manifest-listed version
+  equaling the manifest's pinned integrity (the client-visible pin);
 - packuments and tarball responses byte-identical with `patching:` enabled
   and disabled — substitute mode touches neither serving path;
 - an existing lockfile pinning the vulnerable original installing unchanged
@@ -798,9 +793,8 @@ Tests should cover, at minimum:
   automatically?
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the
-  right delivery — integrity hashes dominate the bytes and do not compress —
-  and is the fallback a name-filtered bulk lookup, a chunked/delta encoding,
-  or both?
+  right delivery, and is the fallback a name-filtered bulk lookup, a
+  chunked/delta encoding, or both?
 - **Default mode.** Is `advertise` the right default for `patching:`, with
   `substitute` as the explicit escalation? (This RFC assumes yes: changing
   what fresh resolutions receive should be a deliberate, visible deployment

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -13,19 +13,19 @@ manifest** ties the two names together, and a per-mount `patching:` policy
 applies it in one of two modes: **advertise**, where consumers adopt patches
 explicitly via package alias overrides
 (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) surfaced through audit
-enrichment, and **substitute**, where the registry serves a ready-made
-**patched-versions document** at a well-known endpoint, which patch-aware
-clients fetch and apply **after version selection**: whenever resolution
-picks a version the document covers, the client resolves the provider's
-aliased artifact instead — recorded like an ordinary alias, with a canonical,
-host-free lockfile resolution — while already-pinned installs are never
-altered.
+enrichment, and **substitute**, where pnpr annotates the vulnerable
+version's entry in served packuments with the patch mapping and a
+patch-aware resolver selects it: whenever resolution picks an annotated
+version, the resolver returns the provider's aliased artifact instead —
+recorded like an ordinary alias, with a canonical, host-free lockfile
+resolution — while already-pinned installs are never altered.
 
-Notably, this requires **no new mount kind** and no changes to how packuments
-or tarballs are served. Both shapes are expressible with
-hosted/upstream/router mounts as already specified; what this RFC adds is the
-manifest protocol, a registry-served patched-versions document, and the
-audit/advisory machinery around it.
+Notably, this requires **no new mount kind**. Both shapes are expressible
+with hosted/upstream/router mounts as already specified; the only
+serving-path addition is the substitute-mode annotation, layered onto
+affected packuments on egress over a pristine cache. What this RFC adds is
+the manifest protocol, that annotation, and the audit/advisory machinery
+around them.
 
 Both shapes extend the invariants of the registry-mounts RFC rather than
 weakening them:
@@ -296,22 +296,21 @@ never run `pnpm audit` never find out. When the deployment's intent is "no
 fresh resolution may pick a version we have a patch for", that is substitute
 mode.
 
-### Substitute mode: a registry-provided patched-versions document
+### Substitute mode: annotated packuments selected by the resolver
 
-Advertise mode's audit enrichment already computes, per vulnerable version,
-the substitution a workspace should adopt. `substitute` mode serves that
-same result wholesale: the registry compiles the pinned, policy-filtered
-manifests into one **patched-versions document** — a flat map from exact
-original versions to alias specs — at a well-known endpoint on each registry
-base that enables it:
+`substitute` mode puts the mapping where the resolver is already looking:
+on the vulnerable version's entry in the packument. For every manifest
+entry the mount's policy accepts, pnpr serves the base packument with an
+annotation on that version — original metadata and `dist` untouched:
 
 ```jsonc
-// GET <registry base>/-/pnpr/patched-versions
-{
-  "schema": "pnpr-patched-versions/1",
-  "versions": {
-    "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4",
-    "lodash@4.17.20": "npm:@echo-patch/lodash@4.17.20"
+// GET /~main/ejs — versions["2.7.4"], annotated on egress
+"2.7.4": {
+  // ...original metadata, original dist...
+  "_pnprPatch": {
+    "patched": "npm:@echo-patch/ejs@2.7.4",
+    "provider": "echo",
+    "fixes": ["GHSA-..."]
   }
 }
 ```
@@ -328,61 +327,63 @@ mounts:
     patching:
       provider: echo
       mode: substitute
-      minSeverity: high      # only include fixes at/above this severity
+      minSeverity: high      # only annotate fixes at/above this severity
 ```
 
-A patch-aware client applies the document **after version selection** as
-well. The proposed client mechanism (a pnpm follow-up RFC) is not a new
-override kind but a semantic extension of the existing one: **an override
-whose selector is an exact version also matches the *picked* version at
-resolution time.** Today such an override rewrites only declared specs, by
-subset — and the only range that is a subset of `2.7.4` is `2.7.4` itself,
-so a dependency declared as `^2.7.0` slips past it even when resolution
-picks `2.7.4`. The extension is therefore strictly additive: every case the
-spec rewrite already handles produces the identical result post-pick, and
-the new behavior covers exactly the picks that previously slipped through —
-which is what the override's author meant all along. The substitution is
-applied exactly once (a substituted target is not re-matched, so maps
-cannot chain or cycle). Because the document's entries are all
-exact-version→exact-spec, they are ordinary overrides under this extension,
-indistinguishable from ones the workspace wrote itself, and the registry
-document is merged beneath the workspace's own overrides as the
-lowest-precedence source. Version selection is never changed — only which
-*build* of the selected version is installed. Everything downstream is
-pnpm's already-shipped alias machinery, and that is the point:
+The annotation is applied **on egress**: the cached upstream packument stays
+byte-identical to what the origin served, and the annotation is layered on
+at response time as a pure function of the pinned manifest snapshot. The
+field is inert for any client that does not know it.
+
+A patch-aware resolver (a pnpm follow-up RFC) selects the annotation
+*inside* the resolve call. pnpm's resolver already separates a dependency's
+**alias** — the key in the dependent's manifest — from the **resolved
+identity** it returns (`id`, `manifest`, `resolution`); that split is how
+`npm:` aliases work today. The patched flow rides it unchanged: resolving
+`ejs@^2.7.0`, the resolver picks `2.7.4` from the packument, sees
+`_pnprPatch`, resolves `@echo-patch/ejs@2.7.4`, and returns *that* result
+(marked `resolvedVia: registry-patch`), while the dependency keeps its
+alias `ejs`. Version selection is never changed — the pick is the key that
+selects the patch — only which *build* of the selected version is
+installed. A substituted result is returned as-is, never re-matched, so
+substitutions cannot chain. And no override semantics change anywhere:
+workspace overrides keep exactly their current meaning, applied to declared
+specs before resolution, and continue to apply here (an override that
+rewrites the spec away from `ejs@2.7.4` means that version is never picked
+and the annotation never consulted). Everything downstream is pnpm's
+already-shipped alias machinery, and that is the point:
 
 - **The lockfile stays canonical and host-free.** A fresh resolution of
-  `^2.7.0` picks `2.7.4`, the document redirects that pick, and the lockfile
-  records the aliased package `@echo-patch/ejs@2.7.4` with a canonical
-  resolution — integrity only, tarball URL recomputed from registry config at
-  install time. Nothing deployment-specific is persisted; portability is
-  exactly that of any aliased dependency.
-- **No pinned install ever changes.** Substitution acts only when a
-  resolution is made. An existing lockfile entry is never touched, and a
-  `--frozen-lockfile` install neither fetches nor applies the document.
-  Substitute at resolution, never at fetch.
-- **Applied registry overrides are recorded in the lockfile.** pnpm already
-  records the overrides a resolution used, and registry-provided entries
-  must leave the same trace: every entry that actually affected the graph is
-  written to a dedicated lockfile section (entry plus source registry) —
-  but *only* applied entries, so the lockfile grows with the workspace's
-  substitutions, not with the org's whole patch catalog. The record serves
-  both audiences: humans and SBOM tooling see *why* `ejs` resolves to
-  `@echo-patch/ejs@2.7.4`, and pnpm gets change detection — a changed or
-  withdrawn entry re-resolves exactly the affected packages, and a new
-  document entry covering a currently locked vulnerable pick adopts the
-  patch on the next non-frozen install (a map lookup over locked
-  `name@version` pairs, no re-resolution sweep).
+  `^2.7.0` picks `2.7.4`, the annotation redirects that pick, and the
+  lockfile records the aliased package `@echo-patch/ejs@2.7.4` under the
+  dependency key `ejs` with a canonical resolution — integrity only,
+  tarball URL recomputed from registry config at install time. It is
+  byte-for-byte the lockfile a hand-written alias override would have
+  produced.
+- **No pinned install ever changes.** The annotation is consulted only when
+  a resolution is made; an existing lockfile entry is never touched, and a
+  `--frozen-lockfile` install reads no packuments at all. Substitute at
+  resolution, never at fetch.
+- **Substitutions are recorded so the lockfile stays self-consistent.** To
+  pnpm's up-to-date check, `ejs: ^2.7.0` resolving to an alias it cannot
+  explain from the workspace's own config would look like an entry needing
+  re-resolution. The follow-up therefore records substituted entries
+  (mapping plus source registry) in a dedicated lockfile section — only
+  applied entries, so the lockfile grows with the workspace, not the
+  provider's catalog. The record lets satisfiability checks accept the
+  aliased entry, lets a withdrawn patch re-resolve exactly the affected
+  packages, and tells humans and SBOM tooling *why* the alias exists.
 - **Provenance is legible and diffable.** The lockfile shows `ejs` resolving
   to `@echo-patch/ejs@2.7.4` and the recorded entry that caused it; when a
   manifest refresh moves a patch to `-sp2`, the next non-frozen resolution
   produces a reviewable lockfile diff in both places.
-- **Opting out is ordinary precedence.** A workspace that must keep a
-  vulnerable original declares its own override for `ejs@2.7.4` (mapping the
-  pick to itself), which outranks the registry-provided document — visible
-  and reviewable, like every other override.
+- **Opting out is an explicit client setting.** With no override merge
+  involved, precedence cannot express refusal; the follow-up defines an
+  ignore list (per package, or per provider) that makes the resolver skip
+  the annotation — declared in workspace config, visible and reviewable
+  like an override.
 
-Clients that are not patch-aware never ask for the document and resolve the
+Clients that are not patch-aware ignore the unknown field and resolve the
 vulnerable original — no worse than today. Per-mount policy can escalate:
 `unawareClients: refuse` makes the tarball route answer a manifest-covered
 vulnerable artifact with the explicit `403`-plus-suggested-override body
@@ -392,53 +393,47 @@ route cannot distinguish a fresh resolution from an old pinned one, so
 which is precisely what "no known-patchable vulnerable artifact leaves this
 registry" means. The default is `serve`.
 
-**Resolution cost.** Matching is a map lookup per pick — nothing for the
-unpatched majority. A matched pick resolves the alias target: an
-exact-version resolution against the patch-scope packument, which is small
-(patched versions only), cached like any other, and fetched in parallel
-with the rest of resolution. That is a second resolution of *that
-dependency*, never of the graph, and the original pick is not wasted work —
-it is the key that selects the patch; there is no way to learn that
-`^2.7.0` lands on `2.7.4` without performing the pick. A fetch-free variant
-— carrying each patched tarball's integrity in the document so the client
-constructs the resolution directly — was considered and set aside: a
-hand-written override will never carry an integrity, so making integrity
-part of override semantics would fork the mechanism into two systems (or
-grow an object-form override type). The trust boundary it would police —
-the patch source's infrastructure, which the deployment does not control —
-is already policed server-side, where pnpr verifies both the patch-scope
-metadata and the tarball bytes against the provider's *signed manifest*
-before serving them (see the manifest rules). Client-carried integrity
-would defend only against pnpr itself failing to enforce that check —
-defense in depth, not a new guarantee — and is parked as an open question
-rather than a mechanism change. Server-side, the map and the patch-scope
-metadata are local, so substitution is a lookup there.
+**Resolution cost.** Discovering patches costs nothing: the mapping rides
+the packument the resolver already fetched, so unpatched packages — and
+workspaces that never resolve a patched version — pay zero, and there is no
+separate catalog to download, cache, or discover. A matched pick resolves
+the alias target: one exact-version resolution against the patch-scope
+packument, which is small (patched versions only), cached like any other,
+and fetched in parallel with the rest of resolution — a second resolution
+of *that dependency*, never of the graph. The original pick is not wasted
+work; it is the key that selects the patch, and there is no way to learn
+that `^2.7.0` lands on `2.7.4` without performing the pick. The annotation
+could additionally carry the patched tarball's integrity and manifest
+essentials so even that one fetch disappears — deliberately not required:
+the trust boundary it would police (the patch source's infrastructure,
+which the deployment does not control) is already policed server-side,
+where pnpr verifies both the patch-scope metadata and the tarball bytes
+against the provider's *signed manifest* before serving them. Client-side
+verification against annotation-carried integrity would defend only against
+pnpr itself failing to enforce that check — defense in depth, parked as an
+open question.
 
-**Server-side and client-side resolution apply the same map at the same
-point.** The flow above is client-side resolution: pnpm reads packuments,
-picks versions locally, and consults its cached copy of the document
-post-pick. When resolution happens in pnpr itself — the resolution endpoint
-of the auth-aware resolution-cache design — the server applies the same
-pinned map at the same logical point: after version selection, before the
-resolution is returned or cached. Two requirements keep the two paths
-coherent, so a graph resolved partly on each side cannot disagree:
-
-- the resolve response reports **which entries were applied** and the
-  document digest they came from, so the client records them in the lockfile
-  section exactly as if it had applied them itself — a server-side
-  substitution must never be less traceable than a client-side one;
-- server-side **resolution-cache keys include the mount's patching policy
-  and the pinned snapshot digest** — otherwise a manifest refresh could keep
-  serving pre-refresh substitutions (or none) out of the cache.
+**Server-side and client-side resolution apply the same mapping at the same
+point.** The flow above is client-side resolution: pnpm reads annotated
+packuments and substitutes inside its own resolve calls. When resolution
+happens in pnpr itself — the resolution endpoint of the auth-aware
+resolution-cache design — the server applies the same annotation logic at
+the same logical point, so returned resolutions are natively aliased and a
+server-side substitution is exactly as traceable as a client-side one: the
+aliased resolution *is* the trace, carrying the same `resolvedVia` marker
+for the lockfile record. One requirement keeps the paths coherent:
+server-side **resolution-cache keys include the mount's patching policy and
+the pinned snapshot digest** — otherwise a manifest refresh could keep
+serving pre-refresh substitutions (or none) out of the cache.
 
 Costs and requirements, stated honestly:
 
-- **Automatic protection reaches only patch-aware clients.** npm and yarn
-  users get advertise-mode discovery (and `refuse`, where enabled). pnpr is
-  pnpm-first, and the document format is deliberately trivial — exact
-  version in, alias spec out — so other tools can consume it, and an org can
-  still mechanically derive blunt bare-name overrides from it for clients
-  that predate the feature.
+- **Automatic protection reaches only patch-aware clients.** For npm and
+  yarn the annotation is inert; they get advertise-mode discovery (and
+  `refuse`, where enabled). pnpr is pnpm-first, and the annotation is
+  deliberately trivial — an alias spec on a version entry — so other
+  resolvers could adopt it, and an org can still derive blunt bare-name
+  overrides from the audit endpoint for clients that predate the feature.
 - **Provider retention becomes load-bearing.** A lockfile aliasing
   `@echo-patch/ejs@2.7.4` installs only while that artifact remains
   available. Providers must treat their patch namespaces as immutable and
@@ -451,34 +446,22 @@ Costs and requirements, stated honestly:
   intent — but it is one more reason registry identity belongs in package
   identity.
 
-Determinism and conflicts: the served document is a pure function of the
+Determinism and conflicts: the annotations are a pure function of the
 mount's `patching:` config plus the pinned manifest snapshots — the same
-determinism contract as router routes. A refresh that changes it is logged
-and diffable, and the document carries a digest/ETag so clients cache it
-cheaply. Within one mount, at most one provider may claim a given original
-`name@version`; two manifests colliding is a config error, not a precedence
-guess. And substitution composes with advertise-mode machinery — the audit
-endpoint still reports the mapping, so a workspace can see which of its
-resolutions came from the registry's document and pin them explicitly if it
+determinism contract as router routes — and a refresh that changes them is
+logged and diffable. Within one mount, at most one provider may claim a
+given original `name@version`; two manifests colliding is a config error,
+not a precedence guess. And substitution composes with advertise-mode
+machinery — the audit endpoint reports the same mapping, so a workspace can
+see which of its resolutions were substituted and pin them explicitly if it
 prefers.
 
-**Document size.** The document grows linearly with the provider's patch
-catalog, and that catalog is advisory-driven: an entry exists only for an
-exact `name@version` that has a backported fix, so growth tracks CVE history
-in patched packages, not the registry. Realistic catalogs are on the order
-of 10³–10⁴ entries; at roughly 80 bytes per entry that is sub-megabyte raw,
-and the shape (one scope prefix, repeated names) compresses to tens of
-kilobytes.
-Policy filtering (`minSeverity`, `requireAdvisoryMatch`) trims it further.
-Delivery cost is bounded by the caching contract rather than the size: the
-document changes only on manifest refresh or config reload, so a client
-caches it machine-wide per registry base (shared across workspaces, like the
-store) and revalidates with `If-None-Match` — the steady-state cost of
-substitute mode is one `304` per resolution run. Should a catalog ever
-outgrow single-document delivery, the escape hatch is a filtered bulk lookup
-shaped like the audit bulk endpoint (the client posts the names it is
-resolving); that variant is deliberately out of scope until real catalog
-sizes demand it.
+**Delivery is proportional by construction.** There is no patch catalog to
+ship: a workspace only ever sees mappings for packages it actually
+resolves, embedded in metadata it was fetching anyway — a few hundred bytes
+on affected version entries of affected packuments. The catalog-scale
+questions a standalone document raises (size bounds, endpoint discovery,
+separate caching and revalidation) do not arise.
 
 ### Advisory screening of patched artifacts
 
@@ -512,12 +495,13 @@ Its advantage is discoverability in one namespace: the patched versions appear
 in `npm view ejs versions`, and adoption is a version-only override with no
 name change. It is rejected as the primary mechanism because:
 
-- **It synthesizes metadata.** The overlay serves a packument that no single
-  origin published — base metadata with foreign *version entries* spliced
-  into the version list. The alias model never modifies a served packument in
-  any mode: the patched-versions document lives beside the registry surface,
-  not inside another origin's metadata — yet grafting buys neither automatic
-  protection (last bullet below) nor a cleaner adoption story.
+- **It synthesizes load-bearing metadata.** The overlay serves a packument
+  that no single origin published — base metadata with foreign *version
+  entries* spliced into the version list, entries every client acts on. The
+  substitute-mode annotation is categorically smaller: an inert extension
+  field on an existing version entry, acted on only by resolvers that opted
+  in — yet grafting buys neither automatic protection (last bullet below)
+  nor a cleaner adoption story.
 - **It requires a new composite mount kind**, with its own validation, routing,
   write-rejection, and access-composition rules. The alias model is ordinary
   packages through ordinary mounts.
@@ -556,53 +540,69 @@ patching have
 a coherent home for it: make the vendor the declared origin (upstream mount),
 where the vendor owns the identity end to end.
 
-### Serving the substitution inside packuments
+### Rewriting `dist` inside served packuments
 
-Two earlier shapes of substitute mode put the mapping into the served
-packument itself instead of a separate document:
+An earlier shape of substitute mode rewrote the vulnerable version's `dist`
+to the patched artifact's tarball URL and integrity. Its appeal is
+universality — every npm client gets auto-patched with no client feature —
+but the patched URL is non-canonical for the original name, so clients
+persist the full URL, baking the deployment host into lockfiles: exactly
+what the mounts RFC's canonical-URL round-tripping exists to prevent, and a
+silent bytes-for-version change for clients that never asked for one. The
+chosen annotation differs in both respects: it *adds* an inert field
+instead of altering `dist`, only a resolver that understands it acts on it,
+and the result is recorded as a first-class aliased identity with a
+canonical, recomputable resolution.
 
-- **Rewrite the vulnerable version's `dist`** to the patched artifact's
-  tarball URL and integrity. Its appeal is universality — every npm client
-  gets auto-patched with no client feature — but the patched URL is
-  non-canonical for the original name, so clients persist the full URL,
-  baking the deployment host into lockfiles: exactly what the mounts RFC's
-  canonical-URL round-tripping exists to prevent. The lockfile records an
-  opaque URL where the alias encoding records a first-class package identity
-  with a canonical, recomputable resolution.
-- **Annotate the vulnerable version** with an extension field
-  (`_pnprPatch: {patched, integrity, ...}`) for patch-aware clients to act
-  on. Lockfile-clean, but it still injects nonstandard fields into another
-  origin's metadata on the serving path, and the client must discover
-  patches one packument at a time.
+### Distributing the mapping as spec-rewriting overrides, unchanged
 
-The registry-provided document subsumes both: the same information, one
-document beside the registry surface, zero changes to packument or tarball
-serving, and one client-side application point after version selection.
-
-### Applying the document under today's override semantics, unchanged
-
-An earlier draft served the document *in overrides format* for the client to
-merge alongside workspace overrides, with no semantic change. Rejected
-because today's semantics cannot express the goal. Overrides rewrite
-**declared specs** before resolution, and a selector matches a declared
-range by subset: `"ejs@2.7.4"` applies to a dependency declared as `2.7.4`,
-but not to `^2.7.0` — whose resolution to `2.7.4` is exactly the case that
-needs protection. Widening the selector cannot fix it: no range selector
-matches `^2.7.0` short of the bare name, and a bare-name override
+The simplest client story would be serving the mapping *in overrides
+format* for clients to merge alongside workspace overrides, with no
+semantic change anywhere. Rejected because today's override semantics
+cannot express the goal. Overrides rewrite **declared specs** before
+resolution, and a selector matches a declared range by subset:
+`"ejs@2.7.4"` applies to a dependency declared as `2.7.4`, but not to
+`^2.7.0` — whose resolution to `2.7.4` is exactly the case that needs
+protection. Widening the selector cannot fix it: no range selector matches
+`^2.7.0` short of the bare name, and a bare-name override
 (`"ejs": "npm:@echo-patch/ejs@2.7.4"`) *changes version selection* — it
 forces every `ejs` in the graph to the patched `2.7.4`, downgrading a
-`^2.7.0` that would have picked a genuinely fixed `2.7.5`.
+`^2.7.0` that would have picked a genuinely fixed `2.7.5`. Any correct
+mechanism must act after version selection — spec rewriting cannot see the
+pick.
 
-The fix is the exact-version extension described in substitute mode, chosen
-over a *separate* post-resolution override kind because for exact-version
-selectors the two application points agree wherever both apply — the only
-subset of `2.7.4` is `2.7.4` itself — so post-pick matching is a strict
-widening of the same override, not a competing mechanism with its own
-precedence rules. The extension deliberately stops at exact selectors:
-applying a *range* selector to picked versions with a range replacement
-would re-open version selection after the resolver closed it and would
-silently reinterpret existing workspace configs, whereas the exact-selector
-case only starts covering picks that previously slipped through.
+### A standalone patched-versions document plus an override extension
+
+The previous draft of substitute mode compiled the manifests into a
+standalone document at a well-known endpoint
+(`/-/pnpr/patched-versions`), applied by the client through a semantic
+extension of overrides: an override whose selector is an exact version
+would also match the *picked* version at resolution time, and the
+document's exact-version→alias entries would merge beneath the workspace's
+own overrides. It satisfies the act-after-selection requirement, and its
+opt-out story is elegant (workspace override precedence). The annotation
+was chosen over it because:
+
+- **Delivery and discovery.** A standalone catalog is a whole protocol
+  surface: endpoint path and discovery, trust/signing, machine-wide
+  caching and revalidation, size bounds and a scale escape hatch. The
+  annotation needs none of it — mappings arrive with exactly the
+  packuments being resolved, proportionally, over the already-authenticated
+  registry connection.
+- **No override-semantics change.** The extension was carefully additive
+  (for an exact-version selector, post-pick matching only covers picks that
+  previously slipped through), but it was still a behavior change to
+  existing workspace configs, with real questions about how it ships.
+  Resolver-side annotation selection leaves override semantics completely
+  untouched.
+
+What the document did better is worth recording: workspace opt-out fell out
+of ordinary override precedence (annotations need an explicit ignore
+setting instead), and the override extension also empowered *hand-written*
+exact-version overrides to catch range-resolved picks — a genuinely useful
+capability that the annotation approach does not deliver. If that proves
+worth having, it can be proposed independently in pnpm; nothing in this
+design conflicts with it.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -641,8 +641,9 @@ except the specific, signed, advisory-matched artifacts the provider patched.
 
 ## Implementation
 
-All registry-side changes are in pnpr-server, and none of them touch the
-mount graph, routing, or the packument/tarball serving paths:
+All registry-side changes are in pnpr-server. The mount graph and routing
+are untouched; substitute mode adds one egress annotation step layered over
+pristine cached packuments:
 
 1. **`patchProviders:` config and manifest machinery.** Parse/validate the
    provider block (scope, source mount, manifest URL, keys, policy);
@@ -657,26 +658,27 @@ mount graph, routing, or the packument/tarball serving paths:
    endpoint from OSV data, adding the namespaced extension field with the
    suggested override spec when a pinned manifest covers a vulnerable
    version.
-4. **Per-mount `patching:` policy and the patched-versions endpoint.**
-   Validate the policy block (known provider, mode, severity gate,
-   `unawareClients`, one substituting provider per original `name@version`
-   per mount); compile the pinned, policy-filtered manifests into the
-   `/-/pnpr/patched-versions` document with a digest/ETag, recompiled only
-   on manifest refresh or config reload; implement `unawareClients: refuse`
-   on the tarball route with the `403` reason body.
+4. **Per-mount `patching:` policy and the egress annotation.** Validate the
+   policy block (known provider, mode, severity gate, `unawareClients`, one
+   substituting provider per original `name@version` per mount); in
+   substitute mode, annotate matched version entries of served packuments
+   on egress as a pure function of the pinned snapshots, leaving cached
+   upstream documents and every `dist` object untouched; implement
+   `unawareClients: refuse` on the tarball route with the `403` reason
+   body.
 5. **Server-side resolution integration.** Where pnpr resolves on the
    client's behalf (the resolution endpoint of the auth-aware
-   resolution-cache design), apply the pinned map post-pick before a
-   resolution is returned or cached, report applied entries and the snapshot
-   digest in the resolve response, and include the patching policy and
-   snapshot digest in resolution-cache keys.
+   resolution-cache design), apply the same annotation logic inside
+   resolution so returned resolutions are natively aliased and carry the
+   substitution marker, and include the patching policy and snapshot digest
+   in resolution-cache keys.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
-overrides from the enriched audit response, and the exact-version override
-extension — an override whose selector is an exact version also matches the
-picked version at resolution time, applied exactly once, with the
-workspace's own overrides outranking the registry-provided patched-versions
-document.
+overrides from the enriched audit response, and the patch-aware resolver —
+selecting `_pnprPatch` inside the resolve call, returning the aliased
+identity (`resolvedVia: registry-patch`), recording substituted entries in
+a dedicated lockfile section so satisfiability checks accept them, with an
+explicit ignore setting for opting out.
 
 Tests should cover, at minimum:
 
@@ -693,24 +695,25 @@ Tests should cover, at minimum:
   patch against the same base version;
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
-- the patched-versions document compiled from pinned manifests, filtered by
-  `minSeverity`, stable between refreshes, and served with a digest/ETag;
+- matched version entries annotated on egress only for manifest-covered,
+  policy-accepted versions, as a pure function of the pinned snapshot;
+- cached upstream packuments staying byte-identical to origin (annotation
+  on egress only), every `dist` object and all tarball responses identical
+  with `patching:` enabled and disabled;
 - the patch-scope packument's `dist.integrity` for a manifest-listed version
   equaling the manifest's pinned integrity (the client-visible pin);
-- packuments and tarball responses byte-identical with `patching:` enabled
-  and disabled — substitute mode touches neither serving path;
 - an existing lockfile pinning the vulnerable original installing unchanged
   through a substitute-mode mount (with `unawareClients: serve`);
 - `unawareClients: refuse` answering manifest-covered vulnerable tarballs
   with `403` plus the suggested override, and leaving uncovered artifacts
   untouched;
 - the one-substituting-provider-per-original rule enforced at config load;
-- server-side resolution applying the same pinned snapshot as the served
-  document, reporting applied entries in resolve responses, and a manifest
-  refresh re-keying (never silently reusing) cached resolutions;
-- a manifest refresh changing the patched-versions document being logged, and
-  previously aliased patched artifacts continuing to serve as long as the
-  provider retains them;
+- server-side resolution returning aliased resolutions from the same pinned
+  snapshot as the served annotations, and a manifest refresh re-keying
+  (never silently reusing) cached resolutions;
+- a manifest refresh changing annotations being logged, and previously
+  aliased patched artifacts continuing to serve as long as the provider
+  retains them;
 - vendor-as-origin deployments (Seal-style `-spN` packuments) proxying
   unchanged through an upstream mount.
 
@@ -730,11 +733,11 @@ Tests should cover, at minimum:
   and as override targets, which is what makes adoption a config edit rather
   than a client feature.
 - **pnpm's config dependencies** (RFC 0004) already distribute shared
-  overrides to many repositories through an installed package; the
-  registry-provided patched-versions document is the same idea with the
-  registry as the distribution channel, and the two can coexist (an org can
-  derive overrides from the document into a config dependency for clients
-  that predate the endpoint).
+  overrides to many repositories through an installed package;
+  annotation-driven substitution serves the same organization-wide goal with
+  the registry as the channel, and the two can coexist (an org can derive
+  blunt overrides from the audit endpoint into a config dependency for
+  clients that predate the resolver feature).
 - **vlt's DepID** (registry as a component of package identity) is the prior
   art for the deferred named-registry encoding.
 - **Socket Certified Patches** demonstrates the repo-local patching shape;
@@ -750,10 +753,10 @@ Tests should cover, at minimum:
   surface this RFC enriches rather than replaces.
 - **Go's `replace` directive with a left-side version**
   (`replace ejs v2.7.4 => patched v2.7.4`) is the closest living precedent
-  for the exact-version override extension: it applies **only when minimal
+  for substituting the selected pick: it applies **only when minimal
   version selection selects exactly that version**, other versions are
   untouched, and it is honored only in the main module — the same
-  substitute-the-selected-pick, workspace-holds-authority shape proposed
+  substitute-the-selected-pick shape the patch-aware resolver performs
   here.
 - **Cargo's `[replace]`** was post-resolution exact-version substitution
   almost verbatim: keyed by an exact package id, it swapped the *source* of
@@ -783,15 +786,15 @@ Tests should cover, at minimum:
   construction, when nodes may not have versions yet — a timing entanglement
   that produced years of bugs, including two consecutive `npm install` runs
   emitting different lockfiles (broken from 8.3.0, fixed in 11.2.0). The
-  extension proposed here matches at one well-defined point, after the pick.
-  npm's rule that the override *value* also counts as a match (so versions
-  cannot be swapped in cycles) is the analogue of this design's
-  applied-exactly-once rule.
+  mechanism proposed here substitutes at one well-defined point inside a
+  single resolver call, after the pick. npm's rule that the override *value*
+  also counts as a match (so versions cannot be swapped in cycles) is the
+  analogue of this design's substituted-results-are-never-re-matched rule.
 - **yarn's `resolutions`** (Berry) match the *declared descriptor* — a
   `foo@^1.0.0` key matches dependents that declared `^1.0.0`, not picks that
   land in it — confirming that every JS package manager's override surface
   is declaration-level today, and none can express "the version resolution
-  actually chose" without an extension like the one proposed.
+  actually chose" without resolver participation as proposed here.
 
 ## Unresolved Questions and Bikeshedding
 
@@ -817,45 +820,33 @@ Tests should cover, at minimum:
   is the provider's attestation the right carrier?
 - **Named-registry encoding timing.** Revisit `echo:ejs@2.7.4`-style
   overrides once the pnpm lockfile registry-identity follow-up lands; the
-  patched-versions document could then carry registry-qualified specs as an
-  alternative encoding.
-- **Document endpoint discovery and trust.** The exact path
-  (`/-/pnpr/patched-versions` vs. a capabilities document), whether the
-  document is signed with the pnpr instance key in addition to being served
-  over the authenticated registry connection, and how a client maps multiple
-  configured registries to multiple documents (fetch from each base? default
-  registry only?).
-- **Exact-version override extension design.** The pnpm-side follow-up must
-  settle how the semantic extension ships (silently, behind a setting, or in
-  a major release — existing configs with exact-version selectors start
-  covering picks they previously missed, which is intended but is a
-  behavior change), whether a registry-provided document is applied by
-  default or behind a setting, how provenance is surfaced (`pnpm why`,
-  install summary), the exact once-only application rule for substituted
-  targets, and whether parent-scoped selectors (`a>b@1.0.0`) participate.
-  The answers shape the document format.
+  annotation could then carry a registry-qualified spec as an alternative
+  encoding.
+- **Patch-aware resolver design.** The pnpm-side follow-up must settle
+  whether annotations are honored by default when present or behind a
+  setting, whether they are honored from *any* registry or only from
+  configured pnpr bases, the opt-out surface (ignore list per package or
+  per provider), how provenance is surfaced (`pnpm why`, install summary,
+  the `resolvedVia` marker), and the annotation field name (`_pnprPatch`
+  vs. something vendor-neutral other resolvers could adopt).
 - **Lockfile recording shape.** The name and format of the lockfile section
-  recording applied registry overrides (alongside the existing `overrides`
-  record), the resolve-response field carrying server-applied entries,
-  whether the document digest is recorded in addition to the applied
-  entries, and the adoption-timing default — is silently adopting a newly
-  published patch for an already-locked pick on the next non-frozen install
-  the right behavior, or should new adoptions require an explicit gesture
-  (`pnpm update --patches`-style) while only *withdrawn* entries act
+  recording substituted entries — it must let satisfiability checks accept
+  an aliased resolution the workspace's own config does not explain, and
+  distinguish it from a hand-written override — and the adoption-timing
+  default: is silently adopting a newly published patch for an
+  already-locked pick on the next non-frozen re-resolution the right
+  behavior, or should new adoptions require an explicit gesture
+  (`pnpm update --patches`-style) while only *withdrawn* patches act
   automatically?
-- **Scale threshold for a filtered variant.** At what measured catalog size
-  (entries, compressed bytes) does the single cached document stop being the
-  right delivery, and is the fallback a name-filtered bulk lookup, a
-  chunked/delta encoding, or both?
-- **Client-side integrity as defense in depth.** The patched content
-  originates from the provider's infrastructure, and pnpr's serving-path
-  verification is what stands between a compromised patch source and
-  clients. Should the document optionally carry each entry's
-  manifest-pinned integrity as a *verification sidecar* — not part of
-  override semantics, so the mechanism does not fork — letting patch-aware
-  clients double-check substituted tarballs against the provider's signed
-  manifest even if pnpr's enforcement failed? Costs document size (hashes
-  do not compress) for a redundant check; deliberately undecided.
+- **Annotation-carried integrity as defense in depth and fast path.** The
+  patched content originates from the provider's infrastructure, and pnpr's
+  serving-path verification is what stands between a compromised patch
+  source and clients. Should the annotation optionally carry the patched
+  artifact's manifest-pinned integrity (and manifest essentials) — letting
+  the resolver construct the substituted resolution without fetching the
+  patch-scope packument, and double-check the bytes against the provider's
+  signed manifest even if pnpr's enforcement failed? A redundant check and
+  a metadata-size cost; deliberately undecided.
 - **Default mode.** Is `advertise` the right default for `patching:`, with
   `substitute` as the explicit escalation? (This RFC assumes yes: changing
   what fresh resolutions receive should be a deliberate, visible deployment

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -5,11 +5,12 @@
 Vendors such as Echo, Seal Security, and Socket ship security-patched builds
 of vulnerable open-source package versions and want to deliver them through
 the registry the organization already uses. pnpr should support this in two
-shapes: a vendor registry as an ordinary **upstream mount** (works today, the
-vendor is the declared origin), and a **patch scope** — the provider publishes
-patched artifacts under its own package namespace (`@echo-patch/ejs@2.7.4`),
-served through ordinary mounts and routes. A signed, pinned **patch
-manifest** ties the two names together, and a per-mount `patching:` policy
+shapes: the vendor's registry as an ordinary **upstream registry** (works
+today, the vendor is the declared origin), and a **patch scope** — the
+provider publishes patched artifacts under its own package namespace
+(`@echo-patch/ejs@2.7.4`), served through ordinary registries and routers. A
+signed, pinned **patch manifest** ties the two names together, and a
+per-registry `patching:` policy
 applies it in one of two modes. Both end in the same client primitive — a
 **post-pick substitution rule** applied by a patch-aware resolver **after
 version selection**: whenever resolution picks a covered version, it
@@ -23,13 +24,13 @@ workspace-stored rules (written by hand or by `pnpm audit --fix`); in
 entry and the resolver substitutes by default, with a per-package ignore
 list to refuse.
 
-Notably, this requires **no new mount kind**. Both shapes are expressible
-with hosted/upstream/router mounts as already specified; the only
+Notably, this requires **no new registry kind**. Both shapes are expressible
+with hosted/upstream/router registries as already specified; the only
 serving-path addition is the annotation, layered onto affected packuments
 on egress over a pristine cache. What this RFC adds is the manifest
 protocol, that annotation, and the audit/advisory machinery around them.
 
-Both shapes extend the invariants of the registry-mounts RFC rather than
+Both shapes extend the invariants of the pnpr registries RFC rather than
 weakening them:
 
 > **Provenance is declared, never inferred.** Every `name@version` resolves to
@@ -40,7 +41,7 @@ weakening them:
 > **An identity's bytes are immutable.** pnpr never serves different bytes
 > under a `name@version` — or a tarball URL — a lockfile may already pin.
 > Choosing patched bytes means choosing either a different declared origin
-> (mount) or a distinct package identity — never a silent byte swap.
+> (registry) or a distinct package identity — never a silent byte swap.
 >
 > **Substitute at resolution, never at fetch.** Patching may change what a
 > *new resolution* is directed to — the same kind of event as a new publish
@@ -82,30 +83,33 @@ major-version migration:
 
 These vendors want a way to plug into pnpr, and pnpr deployments want to
 consume them without handing the vendor authority over every package. The
-mount model gives us the vocabulary to do that precisely.
+registry model gives us the vocabulary to do that precisely.
 
 ## Detailed Explanation
 
 ### Baseline: the vendor as a declared origin
 
-This works with mounts as already specified, with zero new machinery:
+This works with registries as already specified, with zero new machinery:
 
 ```yaml
-mounts:
+registries:
+  acme:
+    type: hosted
+    org: acme
+    access: team:acme
+    patterns: ['@acme/*']
+
   echo:
     type: upstream
     url: https://npm.echo.example/org-acme/
     auth:
       tokenEnv: ECHO_NPM_TOKEN
     access: team:acme
+    # No patterns: serves every name — the router's catch-all.
 
   main:
     type: router
-    routes:
-      - patterns: ['@acme/*']
-        source: acme
-      - patterns: ['**']
-        source: echo
+    sources: [acme, echo]
 ```
 
 The organization has chosen Echo as its artifact source for public packages.
@@ -126,8 +130,8 @@ Two consequences are worth stating:
 - **This makes the lockfile registry-identity follow-up urgent.** The same
   `name@version` now routinely exists with different bytes on `~npmjs` and
   `~echo`. pnpm's current `name@version` package key cannot represent both in
-  one graph (see the mounts RFC's motivation); a patched-registry deployment
-  will hit that gap on day one when a workspace mixes mounts.
+  one graph (see the registries RFC's motivation); a patched-registry
+  deployment will hit that gap on day one when a workspace mixes registries.
 
 ### Patch scopes: patched artifacts under the provider's namespace
 
@@ -145,11 +149,12 @@ original — its packument, versions, dist-tags, or bytes — is touched. pnpr
 serves the patch scope through completely ordinary configuration:
 
 ```yaml
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
+    # No patterns: serves every name — the router's catch-all.
 
   echo-patches:
     type: upstream
@@ -157,14 +162,11 @@ mounts:
     auth:
       tokenEnv: ECHO_NPM_TOKEN
     access: team:acme
+    patterns: ['@echo-patch/*']
 
   main:
     type: router
-    routes:
-      - patterns: ['@echo-patch/*']
-        source: echo-patches
-      - patterns: ['**']
-        source: npmjs
+    sources: [echo-patches, npmjs]
 
 patchProviders:
   echo:
@@ -179,12 +181,18 @@ patchProviders:
       requireAdvisoryMatch: true   # a patch must claim to fix a known advisory
 ```
 
-No new mount kind and no fall-through anywhere: the patch scope is just
-packages, routed by the existing router rules, cached in the existing
-per-mount namespaces, gated by the existing access policies. The new
-configuration surface is `patchProviders:`, which registers the **manifest**
-that ties the two namespaces together — and which a mount's `patching:`
-policy (below) chooses how to apply.
+No new registry kind and no fall-through anywhere: the patch scope is just
+packages. The patch-source registry **declares the provider's scope as its
+namespace** (`patterns: ['@echo-patch/*']`), so routers claim it from that
+declaration, and the namespace is enforced on every path to the registry —
+`/~echo-patches/lodash` is a definitive `404`, which also stops any caller
+from pulling arbitrary public names through the provider's server-owned
+credential. Caching and access policies are the existing per-registry ones.
+The new configuration surface is `patchProviders:`, which registers the
+**manifest** that ties the two namespaces together — and which a registry's
+`patching:` policy (below) chooses how to apply. Validation requires the
+provider's `scope` to be claimed by its source registry's declared
+`patterns`.
 
 ### The patch manifest
 
@@ -295,7 +303,7 @@ substitute mode.
 
 `substitute` mode puts the mapping where the resolver is already looking:
 on the vulnerable version's entry in the packument. For every manifest
-entry the mount's policy accepts, pnpr serves the base packument with an
+entry the registry's policy accepts, pnpr serves the base packument with an
 annotation on that version — original metadata and `dist` untouched:
 
 ```jsonc
@@ -311,14 +319,10 @@ annotation on that version — original metadata and `dist` untouched:
 ```
 
 ```yaml
-mounts:
+registries:
   main:
     type: router
-    routes:
-      - patterns: ['@echo-patch/*']
-        source: echo-patches
-      - patterns: ['**']
-        source: npmjs
+    sources: [echo-patches, npmjs]
     patching:
       provider: echo
       mode: substitute
@@ -428,8 +432,8 @@ the same logical point, so returned resolutions are natively aliased and a
 server-side substitution is exactly as traceable as a client-side one: the
 aliased resolution *is* the trace, carrying the same `resolvedVia` marker
 for the lockfile record. One requirement keeps the paths coherent:
-server-side **resolution-cache keys include the mount's patching policy and
-the pinned snapshot digest** — otherwise a manifest refresh could keep
+server-side **resolution-cache keys include the registry's patching policy
+and the pinned snapshot digest** — otherwise a manifest refresh could keep
 serving pre-refresh substitutions (or none) out of the cache.
 
 Costs and requirements, stated honestly:
@@ -443,19 +447,19 @@ Costs and requirements, stated honestly:
 - **Provider retention becomes load-bearing.** A lockfile aliasing
   `@echo-patch/ejs@2.7.4` installs only while that artifact remains
   available. Providers must treat their patch namespaces as immutable and
-  permanent (the manifest protocol should say so), and pnpr's per-mount cache
-  keeps serving cached patched artifacts through provider outages, like any
-  other mount content.
+  permanent (the manifest protocol should say so), and pnpr's per-registry
+  cache keeps serving cached patched artifacts through provider outages,
+  like any other registry content.
 - **Same range, different policies, different bytes.** Two workspaces
-  resolving the same range through mounts with different `patching:` policies
-  get the same version as different builds. That is the deployment's declared
-  intent — but it is one more reason registry identity belongs in package
-  identity.
+  resolving the same range through registries with different `patching:`
+  policies get the same version as different builds. That is the
+  deployment's declared intent — but it is one more reason registry identity
+  belongs in package identity.
 
 Determinism and conflicts: the annotations are a pure function of the
-mount's `patching:` config plus the pinned manifest snapshots — the same
-determinism contract as router routes — and a refresh that changes them is
-logged and diffable. Within one mount, at most one provider may claim a
+registry's `patching:` config plus the pinned manifest snapshots — the same
+determinism contract as router sources — and a refresh that changes them is
+logged and diffable. Within one registry, at most one provider may claim a
 given original `name@version`; two manifests colliding is a config error,
 not a precedence guess. And substitution composes with advertise-mode
 machinery — the audit endpoint reports the same mapping, so a workspace can
@@ -493,9 +497,10 @@ is what solves it. OSV advisories are keyed by the *original* package name:
 ### Prerelease-version grafting behind the original name
 
 The main alternative — and this RFC's own earlier draft — is an **overlay
-mount** that serves the base origin's packument with provider-patched versions
-grafted in as distinct prerelease-style versions (`ejs@2.7.4-sp1`), routing
-those versions to the patch source and everything else to the base.
+registry kind** that serves the base origin's packument with
+provider-patched versions grafted in as distinct prerelease-style versions
+(`ejs@2.7.4-sp1`), routing those versions to the patch source and everything
+else to the base.
 
 Its advantage is discoverability in one namespace: the patched versions appear
 in `npm view ejs versions`, and adoption is a version-only override with no
@@ -508,9 +513,9 @@ name change. It is rejected as the primary mechanism because:
   field on an existing version entry, acted on only by resolvers that opted
   in — yet grafting buys neither automatic protection (last bullet below)
   nor a cleaner adoption story.
-- **It requires a new composite mount kind**, with its own validation, routing,
-  write-rejection, and access-composition rules. The alias model is ordinary
-  packages through ordinary mounts.
+- **It requires a new composite registry kind**, with its own validation,
+  routing, write-rejection, and access-composition rules. The alias model is
+  ordinary packages through ordinary registries.
 - **Prerelease identifiers fight the ecosystem.** `2.7.4-sp1 < 2.7.4` in
   semver — useful for keeping ranges from matching accidentally, but the same
   property makes every prerelease-aware tool treat the patched artifact as
@@ -528,7 +533,7 @@ name change. It is rejected as the primary mechanism because:
 
 Providers that already ship same-name prerelease patches (Seal's `-spN`) are
 still fully served: their artifact server is a vendor-as-origin upstream
-mount, unchanged.
+registry, unchanged.
 
 ### Fetch-time byte substitution behind the original identity
 
@@ -542,9 +547,8 @@ happened. Substitute mode has none of these properties: the original
 canonical URL serves original bytes forever, and the patched artifact enters
 only through *new resolutions*, under its own aliased identity and integrity,
 recorded in the lockfile. Organizations that want fetch-level same-version
-patching have
-a coherent home for it: make the vendor the declared origin (upstream mount),
-where the vendor owns the identity end to end.
+patching have a coherent home for it: make the vendor the declared origin
+(upstream registry), where the vendor owns the identity end to end.
 
 ### Rewriting `dist` inside served packuments
 
@@ -553,7 +557,7 @@ to the patched artifact's tarball URL and integrity. Its appeal is
 universality — every npm client gets auto-patched with no client feature —
 but the patched URL is non-canonical for the original name, so clients
 persist the full URL, baking the deployment host into lockfiles: exactly
-what the mounts RFC's canonical-URL round-tripping exists to prevent, and a
+what the registries RFC's canonical-URL round-tripping exists to prevent, and a
 silent bytes-for-version change for clients that never asked for one. The
 chosen annotation differs in both respects: it *adds* an inert field
 instead of altering `dist`, only a resolver that understands it acts on it,
@@ -619,7 +623,8 @@ design conflicts with it.
 The most elegant encoding is arguably pnpm's named registries: override
 `ejs@2.7.4` with `echo:ejs@2.7.4` — identical name and version, provenance
 carried entirely by the registry component of the package identity, exactly
-the model vlt's DepID uses and the mounts RFC already endorses for lockfiles.
+the model vlt's DepID uses and the registries RFC already endorses for
+lockfiles.
 
 Deferred, not rejected: it depends on the lockfile registry-identity
 follow-up (today pnpm's `name@version` package key cannot hold `ejs@2.7.4`
@@ -651,14 +656,15 @@ except the specific, signed, advisory-matched artifacts the provider patched.
 
 ## Implementation
 
-All registry-side changes are in pnpr-server. The mount graph and routing
-are untouched; substitute mode adds one egress annotation step layered over
-pristine cached packuments:
+All registry-side changes are in pnpr-server. The registry graph and
+routing are untouched; substitute mode adds one egress annotation step
+layered over pristine cached packuments:
 
 1. **`patchProviders:` config and manifest machinery.** Parse/validate the
-   provider block (scope, source mount, manifest URL, keys, policy);
-   fetch/verify/pin manifests on the refresh interval with logged diffs;
-   reject entries outside the provider's scope, without integrity, or (under
+   provider block (scope, source registry — whose declared `patterns` must
+   claim the scope — manifest URL, keys, policy); fetch/verify/pin
+   manifests on the refresh interval with logged diffs; reject entries
+   outside the provider's scope, without integrity, or (under
    `requireAdvisoryMatch`) without a known advisory in `fixes`.
 2. **Advisory identity mapping.** Screen patch-scope artifacts as their
    manifest-mapped upstream identity, minus the `fixes` list for the pinned
@@ -668,9 +674,9 @@ pristine cached packuments:
    endpoint from OSV data, adding the namespaced extension field with the
    suggested override spec when a pinned manifest covers a vulnerable
    version.
-4. **Per-mount `patching:` policy and the egress annotation.** Validate the
-   policy block (known provider, mode, severity gate, `enforcement`, one
-   substituting provider per original `name@version` per mount); in
+4. **Per-registry `patching:` policy and the egress annotation.** Validate
+   the policy block (known provider, mode, severity gate, `enforcement`,
+   one substituting provider per original `name@version` per registry); in
    substitute mode, annotate matched version entries of served packuments
    on egress as a pure function of the pinned snapshots, leaving cached
    upstream documents and every `dist` object untouched; implement
@@ -691,13 +697,15 @@ submitted alongside this one.
 
 Tests should cover, at minimum:
 
-- provider config validation (unknown source mount, scope collisions between
-  providers, unsigned/tampered manifests, out-of-scope entries, missing
-  integrity, `requireAdvisoryMatch` violations);
+- provider config validation (unknown source registry, a scope the source
+  registry's `patterns` do not claim, scope collisions between providers,
+  unsigned/tampered manifests, out-of-scope entries, missing integrity,
+  `requireAdvisoryMatch` violations);
 - manifest refresh changing derived data only at refresh, with the change
   logged;
 - patch-scope packages serving through ordinary routing with the source
-  mount's access policy enforced;
+  registry's access policy and declared namespace enforced (a non-scope
+  name on the patch-source registry is a definitive `404`);
 - integrity mismatch between manifest and patch source surfacing as an error;
 - advisory mapping: a patched artifact not flagged by fixed advisories,
   flagged by unrelated ones, and flagged by advisories published *after* the
@@ -713,7 +721,7 @@ Tests should cover, at minimum:
 - the patch-scope packument's `dist.integrity` for a manifest-listed version
   equaling the manifest's pinned integrity (the client-visible pin);
 - an existing lockfile pinning the vulnerable original installing unchanged
-  through a substitute-mode mount (with `enforcement: serve`);
+  through a substitute-mode registry (with `enforcement: serve`);
 - `enforcement: refuse` answering manifest-covered vulnerable tarballs with
   `403` plus the suggested patch for every caller, and leaving uncovered
   artifacts untouched;
@@ -725,7 +733,7 @@ Tests should cover, at minimum:
   aliased patched artifacts continuing to serve as long as the provider
   retains them;
 - vendor-as-origin deployments (Seal-style `-spN` packuments) proxying
-  unchanged through an upstream mount.
+  unchanged through an upstream registry.
 
 ## Prior Art
 

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -385,6 +385,23 @@ route cannot distinguish a fresh resolution from an old pinned one, so
 which is precisely what "no known-patchable vulnerable artifact leaves this
 registry" means. The default is `serve`.
 
+**Server-side and client-side resolution apply the same map at the same
+point.** The flow above is client-side resolution: pnpm reads packuments,
+picks versions locally, and consults its cached copy of the document
+post-pick. When resolution happens in pnpr itself — the resolution endpoint
+of the auth-aware resolution-cache design — the server applies the same
+pinned map at the same logical point: after version selection, before the
+resolution is returned or cached. Two requirements keep the two paths
+coherent, so a graph resolved partly on each side cannot disagree:
+
+- the resolve response reports **which entries were applied** and the
+  document digest they came from, so the client records them in the lockfile
+  section exactly as if it had applied them itself — a server-side
+  substitution must never be less traceable than a client-side one;
+- server-side **resolution-cache keys include the mount's patching policy
+  and the pinned snapshot digest** — otherwise a manifest refresh could keep
+  serving pre-refresh substitutions (or none) out of the cache.
+
 Costs and requirements, stated honestly:
 
 - **Automatic protection reaches only patch-aware clients.** npm and yarn
@@ -617,6 +634,12 @@ mount graph, routing, or the packument/tarball serving paths:
    `/-/pnpr/patched-versions` document with a digest/ETag, recompiled only on
    manifest refresh or config reload; implement `unawareClients: refuse` on
    the tarball route with the `403` reason body.
+5. **Server-side resolution integration.** Where pnpr resolves on the
+   client's behalf (the resolution endpoint of the auth-aware
+   resolution-cache design), apply the pinned map post-pick before a
+   resolution is returned or cached, report applied entries and the snapshot
+   digest in the resolve response, and include the patching policy and
+   snapshot digest in resolution-cache keys.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
 overrides from the enriched audit response, and the exact-version override
@@ -650,6 +673,9 @@ Tests should cover, at minimum:
   with `403` plus the suggested override, and leaving uncovered artifacts
   untouched;
 - the one-substituting-provider-per-original rule enforced at config load;
+- server-side resolution applying the same pinned snapshot as the served
+  document, reporting applied entries in resolve responses, and a manifest
+  refresh re-keying (never silently reusing) cached resolutions;
 - a manifest refresh changing the patched-versions document being logged, and
   previously aliased patched artifacts continuing to serve as long as the
   provider retains them;
@@ -734,11 +760,12 @@ Tests should cover, at minimum:
   The answers shape the document format.
 - **Lockfile recording shape.** The name and format of the lockfile section
   recording applied registry overrides (alongside the existing `overrides`
-  record), whether the document digest is recorded in addition to the
-  applied entries, and the adoption-timing default — is silently adopting a
-  newly published patch for an already-locked pick on the next non-frozen
-  install the right behavior, or should new adoptions require an explicit
-  gesture (`pnpm update --patches`-style) while only *withdrawn* entries act
+  record), the resolve-response field carrying server-applied entries,
+  whether the document digest is recorded in addition to the applied
+  entries, and the adoption-timing default — is silently adopting a newly
+  published patch for an already-locked pick on the next non-frozen install
+  the right behavior, or should new adoptions require an explicit gesture
+  (`pnpm update --patches`-style) while only *withdrawn* entries act
   automatically?
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -325,17 +325,23 @@ mounts:
       minSeverity: high      # only include fixes at/above this severity
 ```
 
-A patch-aware client (a small pnpm follow-up) fetches the document once per
-resolution run and applies it **after version selection** — deliberately
-*not* as a pnpm override. Overrides rewrite declared specs and match them by
-subset, so an exact-version key like `ejs@2.7.4` would never apply to a
-dependency declared as `^2.7.0` — and `^2.7.0` picking `2.7.4` is exactly the
-fresh-resolution case substitute mode exists for. Instead, the client
-resolves every spec exactly as it does today, and when the **picked** version
-appears in the document, it resolves the mapped alias target in its place.
-Version selection is never changed — only which *build* of the selected
-version is installed. Everything downstream is pnpm's already-shipped alias
-machinery, and that is the point:
+A patch-aware client applies the document **after version selection** —
+deliberately *not* as a spec-rewriting override. Today's overrides rewrite
+declared specs and match them by subset, so an exact-version key like
+`ejs@2.7.4` would never apply to a dependency declared as `^2.7.0` — and
+`^2.7.0` picking `2.7.4` is exactly the fresh-resolution case substitute mode
+exists for. The proposed client mechanism (a pnpm follow-up RFC) is a second
+override kind, **resolution overrides**: selectors matched against the
+**picked** version after the resolver has chosen it, replacing that pick with
+the target spec. Matching a concrete version is *simpler* than today's
+subset-against-declared-range semantics (`semver.satisfies(picked, selector)`),
+the substitution is applied exactly once (a substituted target is not
+re-matched, so maps cannot chain or cycle), and workspaces can declare
+resolution overrides of their own — the registry-provided document is merged
+beneath them as the lowest-precedence source. Version selection is never
+changed — only which *build* of the selected version is installed.
+Everything downstream is pnpm's already-shipped alias machinery, and that is
+the point:
 
 - **The lockfile stays canonical and host-free.** A fresh resolution of
   `^2.7.0` picks `2.7.4`, the document redirects that pick, and the lockfile
@@ -350,10 +356,11 @@ machinery, and that is the point:
 - **Provenance is legible and diffable.** The lockfile shows `ejs` resolving
   to `@echo-patch/ejs@2.7.4`; when a manifest refresh moves a patch to
   `-sp2`, the next non-frozen resolution produces a reviewable lockfile diff.
-- **Opting out is explicit workspace config.** A workspace that must keep a
-  vulnerable original declares the exclusion in its own config (the pnpm
-  follow-up defines the exact setting — e.g., an ignore list for registry
-  patches), visible and reviewable like an override.
+- **Opting out is ordinary precedence.** A workspace that must keep a
+  vulnerable original declares its own resolution override for
+  `ejs@2.7.4` (mapping the pick to itself), which outranks the
+  registry-provided document — visible and reviewable, like every other
+  override.
 
 Clients that are not patch-aware never ask for the document and resolve the
 vulnerable original — no worse than today. Per-mount policy can escalate:
@@ -512,7 +519,7 @@ The registry-provided document subsumes both: the same information, one
 document beside the registry surface, zero changes to packument or tarball
 serving, and one client-side application point after version selection.
 
-### Applying the document as literal pnpm overrides
+### Applying the document as spec-rewriting overrides
 
 An earlier draft served the document *in overrides format* for the client to
 merge alongside workspace overrides. Rejected because the semantics do not
@@ -526,7 +533,11 @@ version selection* — it forces every `ejs` in the graph to the patched
 `2.7.4`, downgrading a `^2.7.0` that would have picked a genuinely fixed
 `2.7.5`. Post-pick substitution has neither problem: the resolver picks
 whatever it would have picked, and only a picked version with a patch is
-swapped for its patched build of the *same* version.
+swapped for its patched build of the *same* version. That is why the client
+mechanism is proposed as a second override kind matched after resolution —
+**resolution overrides** — rather than a reuse of spec rewriting: overrides
+stay the answer, applied at the stage where the question can actually be
+asked.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -590,8 +601,10 @@ mount graph, routing, or the packument/tarball serving paths:
    the tarball route with the `403` reason body.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
-overrides from the enriched audit response, and post-pick substitution from
-the registry-provided patched-versions document during resolution.
+overrides from the enriched audit response, and the **resolution overrides**
+extension — override selectors matched against the picked version, applied
+exactly once, with workspace-declared entries outranking the
+registry-provided patched-versions document.
 
 Tests should cover, at minimum:
 
@@ -691,14 +704,14 @@ Tests should cover, at minimum:
   over the authenticated registry connection, and how a client maps multiple
   configured registries to multiple documents (fetch from each base? default
   registry only?).
-- **pnpm-side application semantics.** Does pnpm apply a registry-provided
-  patched-versions document by default when the registry offers one, or
-  behind a setting? What is the per-package opt-out surface, and how is
-  provenance surfaced (`pnpm why`, install summary)? How does an existing
-  lockfile interact with a changed document — re-resolve only on ordinary
-  re-resolution events, or also when the document digest changes? These
-  belong in the pnpm follow-up RFC, but the answers shape the document
-  format.
+- **Resolution-overrides design.** The pnpm-side follow-up must settle the
+  syntax (a separate field vs. an extension of the existing `overrides`
+  block), whether a registry-provided document is applied by default or
+  behind a setting, how provenance is surfaced (`pnpm why`, install
+  summary), the exact once-only application rule for substituted targets,
+  and how an existing lockfile interacts with a changed document —
+  re-resolve only on ordinary re-resolution events, or also when the
+  document digest changes? The answers shape the document format.
 - **Scale threshold for a filtered variant.** At what measured catalog size
   (entries, compressed bytes) does the single cached document stop being the
   right delivery, and is the fallback a name-filtered bulk lookup, a

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -8,14 +8,20 @@ the registry the organization already uses. pnpr should support this in two
 shapes: a vendor registry as an ordinary **upstream mount** (works today, the
 vendor is the declared origin), and a **patch scope** — the provider publishes
 patched artifacts under its own package namespace (`@echo-patch/ejs@2.7.4`),
-served through ordinary mounts and routes, and consumers adopt them via
-**package alias overrides** (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`). A
-signed, pinned **patch manifest** ties the two names together, driving audit
-enrichment and advisory mapping.
+served through ordinary mounts and routes. A signed, pinned **patch
+manifest** ties the two names together, and a per-mount `patching:` policy
+applies it in one of two modes: **advertise**, where consumers adopt patches
+explicitly via package alias overrides
+(`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) surfaced through audit
+enrichment, and **substitute**, where pnpr rewrites the vulnerable version's
+`dist` in served packuments so that *fresh resolutions* automatically receive
+the patched artifact — visibly recorded in the resulting lockfile — while
+already-pinned installs are never altered.
 
 Notably, this requires **no new mount kind**. Both shapes are expressible with
 hosted/upstream/router mounts as already specified; what this RFC adds is the
-manifest protocol and the audit/advisory machinery around it.
+manifest protocol, a packument rewrite step attached to existing mounts, and
+the audit/advisory machinery around it.
 
 Both shapes extend the invariants of the registry-mounts RFC rather than
 weakening them:
@@ -26,9 +32,15 @@ weakening them:
 > substitution behind the original name.
 >
 > **An identity's bytes are immutable.** pnpr never serves different bytes
-> under a `name@version` a lockfile may already pin. Choosing patched bytes
-> means choosing either a different declared origin (mount) or a distinct
-> package identity — never a silent byte swap.
+> under a `name@version` — or a tarball URL — a lockfile may already pin.
+> Choosing patched bytes means choosing either a different declared origin
+> (mount) or a distinct package identity — never a silent byte swap.
+>
+> **Substitute at resolution, never at fetch.** Patching may change what a
+> *new resolution* is directed to — the same kind of event as a new publish
+> or a dist-tag move — and the result is recorded explicitly in the client's
+> lockfile. Patching never changes what an already-recorded resolution
+> fetches.
 
 ## Motivation
 
@@ -161,11 +173,12 @@ patchProviders:
       requireAdvisoryMatch: true   # a patch must claim to fix a known advisory
 ```
 
-No new mount kind, no synthesized packuments, no fall-through anywhere: the
-patch scope is just packages, routed by the existing router rules, cached in
-the existing per-mount namespaces, gated by the existing access policies. The
-new configuration surface is `patchProviders:`, which registers the
-**manifest** that ties the two namespaces together.
+No new mount kind and no fall-through anywhere: the patch scope is just
+packages, routed by the existing router rules, cached in the existing
+per-mount namespaces, gated by the existing access policies. The new
+configuration surface is `patchProviders:`, which registers the **manifest**
+that ties the two namespaces together — and which a mount's `patching:`
+policy (below) chooses how to apply.
 
 ### The patch manifest
 
@@ -204,10 +217,11 @@ package versions to their patched counterparts:
   because adoption is always an exact pin produced from the manifest — no
   range resolution against upstream expectations ever happens there.
 
-### How clients adopt patched versions
+### Advertise mode: explicit adoption via alias overrides
 
-Adoption is a **package alias override** in the consuming workspace — the
-mechanism pnpm already has for substituting one package for another:
+In `advertise` mode, adoption is a **package alias override** in the consuming
+workspace — the mechanism pnpm already has for substituting one package for
+another:
 
 ```jsonc
 {
@@ -233,10 +247,11 @@ Three adoption paths, from least to most automatic:
    the field ignore it.
 3. **`pnpm audit --fix` (pnpm follow-up, out of scope here).** pnpm reads the
    enriched audit response and writes the alias overrides mechanically. This
-   is deliberately a *write-my-config* flow, not a resolution-time behavior:
-   the override is visible in the workspace manifest and lockfile, reviewable
-   in the PR that introduces it, and removable when the team upgrades away
-   from the vulnerable base version.
+   is deliberately a *write-my-config* flow: the override is visible in the
+   workspace manifest and lockfile, reviewable in the PR that introduces it,
+   and removable when the team upgrades away from the vulnerable base
+   version. (Registry-side resolution-time behavior is substitute mode,
+   below.)
 
 What the alias buys over other encodings of "patched artifact":
 
@@ -252,6 +267,105 @@ What the alias buys over other encodings of "patched artifact":
 - **No prerelease semantics.** Tools that treat any prerelease as unstable —
   `npm outdated`, Renovate/Dependabot version filtering, semver-range
   tooling — never see a prerelease identifier on the adoption path.
+
+Advertise mode's limit is that it is **opt-in per workspace**: a fresh
+`pnpm install` in a repository that has not written the override resolves
+`^2.7.0` to the vulnerable original, exactly as before. Repositories that
+never run `pnpm audit` never find out. When the deployment's intent is "no
+fresh resolution may pick a version we have a patch for", that is substitute
+mode.
+
+### Substitute mode: automatic patching of fresh resolutions
+
+`substitute` mode makes the registry apply the manifest itself, at
+**resolution time**. The `patching:` policy attaches to any read-serving
+mount (upstream or router) and rewrites the packuments that mount serves:
+
+```yaml
+mounts:
+  main:
+    type: router
+    routes:
+      - patterns: ['@echo-patch/*']
+        source: echo-patches
+      - patterns: ['**']
+        source: npmjs
+    patching:
+      provider: echo
+      mode: substitute
+      minSeverity: high      # only substitute for fixes at/above this severity
+```
+
+For every manifest entry `ejs@2.7.4 → @echo-patch/ejs@2.7.4`, the served
+packument for `ejs` keeps the version `2.7.4` — same version list, same
+dist-tags — but that version's `dist` now carries the **patched artifact's
+tarball URL and integrity**, plus a marker object naming the provider, the
+patched identity, and the advisories fixed:
+
+```jsonc
+"2.7.4": {
+  // ...original metadata...
+  "dist": {
+    "tarball": "https://<pnpr>/~echo-patches/@echo-patch/ejs/-/ejs-2.7.4.tgz",
+    "integrity": "sha512-<patched>"
+  },
+  "_pnprPatch": {
+    "of": "ejs@2.7.4",
+    "patched": "@echo-patch/ejs@2.7.4",
+    "provider": "echo",
+    "fixes": ["GHSA-..."]
+  }
+}
+```
+
+Why this is safe where fetch-time byte swapping is not:
+
+- **No pinned install ever changes.** An existing lockfile that resolved the
+  original `ejs@2.7.4` holds the original integrity and reconstructs the
+  canonical tarball URL (`<base>/ejs/-/ejs-2.7.4.tgz`) — which continues to
+  serve the original base-origin bytes, forever. Substitution happens only in
+  the *metadata that new resolutions read*, never on the tarball route.
+- **The substitution is recorded, not hidden.** The patched tarball URL is
+  non-canonical for the package name `ejs`, so pnpm's lockfile writer
+  persists it in full (this is existing behavior for non-canonical
+  resolutions). The resulting lockfile literally shows
+  `@echo-patch/ejs` in the resolution of `ejs@2.7.4` — reviewable in the PR
+  that first creates it, diffable when a patch revision changes it, and
+  reproducible thereafter because the URL and integrity pin exact bytes.
+- **Deterministic between manifest refreshes.** Which versions are rewritten
+  is a pure function of the mount's `patching:` config plus the pinned
+  manifest snapshot — the same determinism contract as router routes. A
+  refresh that changes any substitution is logged and diffable.
+- **The version number still tells the truth.** The application resolves,
+  installs, and runs `2.7.4` — the patched build of it, from a declared
+  provider namespace, with the provenance one `dist.tarball` away.
+
+Costs, stated honestly:
+
+- **Lockfile portability.** The persisted patched tarball URL embeds the pnpr
+  deployment host, which the mounts RFC works hard to keep out of lockfiles.
+  The exposure is limited to substituted entries, but moving a deployment
+  means those entries must be re-resolved (or rewritten by a future
+  registry-identity-aware lockfile format, which would restore portability
+  for patched entries too).
+- **Provider retention becomes load-bearing.** A lockfile pointing at
+  `@echo-patch/ejs@2.7.4` installs only while that artifact remains
+  available. Providers must treat their patch namespaces as immutable and
+  permanent (the manifest protocol should say so), and pnpr's per-mount cache
+  keeps serving cached patched artifacts through provider outages, like any
+  other mount content.
+- **Range semantics shift by one policy layer.** Two workspaces resolving the
+  same range through mounts with different `patching:` policies get different
+  bytes (same version, different builds). That is the deployment's declared
+  intent — but it is one more reason registry identity belongs in package
+  identity.
+
+One rule guards against silent conflicts: within one mount, at most one
+provider may substitute for a given original `name@version`; two manifests
+claiming the same original is a config error, not a precedence guess. And
+substitution composes with advertise-mode machinery — the audit endpoint
+still reports the mapping, so a workspace can see which of its resolutions
+were substituted and pin them explicitly if it prefers.
 
 ### Advisory screening of patched artifacts
 
@@ -285,11 +399,13 @@ Its advantage is discoverability in one namespace: the patched versions appear
 in `npm view ejs versions`, and adoption is a version-only override with no
 name change. It is rejected as the primary mechanism because:
 
-- **It synthesizes metadata.** The overlay serves a packument that no single
-  origin published — base metadata with foreign versions spliced in. That is
-  declared and deterministic, but it is still the one place in the design
-  where pnpr manufactures a document blending two origins, and the alias
-  model needs nothing like it.
+- **It synthesizes more metadata for less.** The overlay serves a packument
+  that no single origin published — base metadata with foreign *version
+  entries* spliced into the version list. Substitute mode's rewrite is
+  strictly narrower (one `dist` object under an existing version, marked as
+  such), and advertise mode needs no rewriting at all — yet grafting buys
+  neither automatic protection (last bullet below) nor a cleaner adoption
+  story.
 - **It requires a new composite mount kind**, with its own validation, routing,
   write-rejection, and access-composition rules. The alias model is ordinary
   packages through ordinary mounts.
@@ -302,21 +418,30 @@ name change. It is rejected as the primary mechanism because:
   the version the application pinned nor a version upstream ever published.
   `@echo-patch/ejs@2.7.4` keeps the real version and moves the difference
   into the name, where provenance belongs.
+- **It cannot protect fresh resolutions either.** Because prereleases sort
+  below their base version and match no ordinary range, `^2.7.0` never
+  resolves to `2.7.4-sp1` — grafting has exactly the same opt-in-only limit
+  as advertise mode, while paying all the costs above. Substitute mode covers
+  fresh resolutions without prerelease identifiers.
 
 Providers that already ship same-name prerelease patches (Seal's `-spN`) are
 still fully served: their artifact server is a vendor-as-origin upstream
 mount, unchanged.
 
-### Same-version byte substitution behind the original name
+### Fetch-time byte substitution behind the original identity
 
-Rejected in any pnpr-mediated form. Serving provider bytes under the base
-origin's `name@version` means the same identity yields different integrity
-depending on when it was first resolved — breaking lockfile verification for
-existing consumers the moment a patch appears, poisoning shared caches with
-ambiguity about which bytes are "the" version, and hiding the substitution
-from every human reading a lockfile. Organizations that want same-version
-patching have a coherent home for it: make the vendor the declared origin
-(upstream mount), where the vendor owns the identity end to end.
+Rejected in any pnpr-mediated form — and worth distinguishing carefully from
+substitute mode. Fetch-time substitution serves provider bytes for the
+*original* canonical tarball URL, so the same recorded resolution yields
+different integrity depending on when it is fetched: existing lockfiles break
+the moment a patch appears, shared caches become ambiguous about which bytes
+are "the" version, and nothing in any lockfile records that a substitution
+happened. Substitute mode has none of these properties: the original
+canonical URL serves original bytes forever, and the patched artifact enters
+only through *new resolutions*, under its own URL and integrity, recorded in
+the lockfile. Organizations that want fetch-level same-version patching have
+a coherent home for it: make the vendor the declared origin (upstream mount),
+where the vendor owns the identity end to end.
 
 ### Named-registry aliases: same name, same version, different registry
 
@@ -355,8 +480,9 @@ except the specific, signed, advisory-matched artifacts the provider patched.
 
 ## Implementation
 
-All registry-side changes are in pnpr-server, and none of them touch the mount
-graph, routing, or serving paths:
+All registry-side changes are in pnpr-server, and none of them change the
+mount graph or routing; substitute mode adds one rewrite step on the
+packument-serving path:
 
 1. **`patchProviders:` config and manifest machinery.** Parse/validate the
    provider block (scope, source mount, manifest URL, keys, policy);
@@ -371,6 +497,12 @@ graph, routing, or serving paths:
    endpoint from OSV data, adding the namespaced extension field with the
    suggested override spec when a pinned manifest covers a vulnerable
    version.
+4. **Per-mount `patching:` policy and the substitute rewriter.** Validate the
+   policy block (known provider, mode, severity gate, one substituting
+   provider per original `name@version` per mount); in substitute mode,
+   rewrite matched versions' `dist` to the patched artifact's URL and
+   integrity and attach the `_pnprPatch` marker, leaving version lists,
+   dist-tags, and the tarball routes untouched.
 
 Client-side follow-ups (separate pnpm RFC): `pnpm audit --fix` writing alias
 overrides from the enriched audit response.
@@ -390,6 +522,16 @@ Tests should cover, at minimum:
   patch against the same base version;
 - audit bulk endpoint carrying the override-spec extension for a vulnerable
   version with a manifest entry, and omitting it otherwise;
+- substitute mode rewriting `dist` (URL, integrity, marker) for matched
+  versions on fresh packument reads while the canonical tarball URL for the
+  original version keeps serving the original bytes;
+- an existing lockfile pinning the original version installing unchanged
+  through a substitute-mode mount (canonical URL reconstruction + original
+  integrity);
+- severity gating (`minSeverity`) and the one-substituting-provider-per-
+  original rule enforced at config load;
+- a manifest refresh changing a substitution being logged, and prior patched
+  URLs continuing to serve as long as the provider retains them;
 - vendor-as-origin deployments (Seal-style `-spN` packuments) proxying
   unchanged through an upstream mount.
 
@@ -445,7 +587,20 @@ Tests should cover, at minimum:
   upstream identity) as an endpoint so downstream tooling can resolve it, or
   is the provider's attestation the right carrier?
 - **Named-registry encoding timing.** Revisit `echo:ejs@2.7.4`-style
-  overrides once the pnpm lockfile registry-identity follow-up lands.
+  overrides once the pnpm lockfile registry-identity follow-up lands. That
+  work would also restore lockfile portability for substitute-mode entries
+  (registry identity instead of an absolute patched-tarball URL).
+- **Substitute-mode opt-out surface.** Should a workspace be able to refuse
+  substitution for a specific package (pin the vulnerable original
+  deliberately) without addressing the base mount directly — e.g., an
+  override on the original canonical spec — and should pnpr honor or flag
+  that?
+- **Default mode.** Is `advertise` the right default for `patching:`, with
+  `substitute` as the explicit escalation? (This RFC assumes yes: silent
+  byte-provenance changes on fresh resolutions should be a deliberate,
+  visible deployment decision.)
+- **Marker field name.** `_pnprPatch` vs. something vendor-neutral tooling
+  could standardize on.
 - **Interaction with package screening.** The separate screening RFC's block
   responses could advertise "a patched artifact is available" via the same
   manifest data. That integration is optional in both directions; neither RFC

--- a/pnpr/text/0000-patch-providers.md
+++ b/pnpr/text/0000-patch-providers.md
@@ -759,12 +759,23 @@ Tests should cover, at minimum:
   almost verbatim: keyed by an exact package id, it swapped the *source* of
   an already-resolved node, and the replacement was required to keep the
   same name and version — precisely the same-version-different-build
-  contract of a security patch. It was deprecated in favor of `[patch]`
-  because users wanted *version-changing* overrides (unpublished bumps),
-  which `[replace]` could not express — a need this design leaves with
-  pnpm's existing spec-rewriting overrides, keeping the post-pick mechanism
-  for the case where even Cargo's docs note `[patch]` merely "acts just
-  like `[replace]`": identical name and version, different source.
+  contract of a security patch. It was deprecated in favor of `[patch]`,
+  which instead augments the candidate set a source offers *before*
+  resolution — because users wanted *version-changing* overrides
+  (unpublished bumps `[replace]` could not express), and because mutating
+  the graph behind the resolver's back broke resolver-derived behavior such
+  as feature unification. Neither of `[patch]`'s two moves transfers to
+  npm's model: candidate *replacement* (same version, different bytes)
+  works in Cargo because source is part of package identity in
+  `Cargo.lock`, which npm's `(name, version)` identity cannot represent —
+  the rejected dist-rewrite; candidate *addition* works because a Cargo
+  patch carries a real version that ranges select, whereas an npm patched
+  artifact pinned to the same version number can only be distinguished by a
+  prerelease suffix that ranges exclude — the rejected grafting. That is
+  why this design moves identity into the *name* (patch scope) and keeps
+  `[replace]`-style post-pick substitution, with the applied-exactly-once
+  rule standing in for the graph-mutation opacity that bit Cargo, and the
+  version-changing need left with pnpm's spec-rewriting overrides.
 - **npm's overrides (RFC 0036)** are the cautionary tale for *where* to
   match. npm's version-keyed overrides do try to match resolved versions
   ("a match if the named package specifier would be satisfied by the

--- a/text/0000-post-pick-substitution.md
+++ b/text/0000-post-pick-substitution.md
@@ -1,24 +1,31 @@
-# Post-pick dependency substitution (patch-aware resolution)
+# Exact-version overrides apply to resolved versions
 
 ## Summary
 
-pnpm's resolver gains one primitive: a **post-pick substitution rule** —
-"when version resolution picks `name@version`, resolve this alias spec in
-its place." Rules come from two sources: **workspace config** (explicit
-adoption of registry-advertised security patches, written by hand or by
-`pnpm audit --fix`) and **registry annotations** (`_pnprPatch` fields served
-by a pnpr registry in substitute mode, applied by default and refusable per
-package via an ignore list). A substituted dependency is recorded in the
-lockfile as an ordinary alias with a canonical, host-free resolution, plus a
-record explaining why the alias exists. Version selection itself never
-changes — only which *build* of the selected version is installed.
+Two related changes to pnpm's resolution, forming the client half of the
+pnpr patch-provider design
+([`pnpr/text/0000-patch-providers.md`](../pnpr/text/0000-patch-providers.md)):
 
-This is the client half of the pnpr patch-provider design
-([`pnpr/text/0000-patch-providers.md`](../pnpr/text/0000-patch-providers.md));
-the registry half (patch scopes, signed manifests, annotation serving, audit
-enrichment, registry-side enforcement) is specified there. This RFC is
-useful on its own — workspace-declared rules require no pnpr — but its
-motivating consumer is registry-delivered security patches.
+1. **A semantics fix to overrides.** An override whose selector is an exact
+   version also applies when version resolution **picks** that version.
+   Today such an override only rewrites declared specs, matched by range
+   subset — so `"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"` covers a
+   dependency declared as `2.7.4` but silently misses every `^2.7.0` that
+   resolves to `2.7.4`, which is almost never what its author meant. The
+   fix is always on: it strictly widens exact-selector overrides to the
+   picks they were written for, and changes nothing else.
+2. **Registry-supplied overrides.** A pnpr registry in substitute mode
+   annotates a vulnerable version's packument entry (`_pnprPatch`) with the
+   mapping to its patched build. The resolver treats such an annotation as
+   a registry-supplied exact-version override at the **lowest precedence**:
+   any workspace override claiming the same pick — including a self-mapping
+   that keeps the original — outranks it.
+
+A substituted dependency is recorded in the lockfile as an ordinary alias
+with a canonical, host-free resolution; workspace-side substitutions are
+ordinary overrides, recorded and change-detected by the machinery that
+records overrides today. Version selection itself never changes — only
+which *build* of the selected version is installed.
 
 ## Motivation
 
@@ -28,75 +35,104 @@ package name (`@echo-patch/ejs@2.7.4` is the patched build of `ejs@2.7.4`).
 Adopting such a patch means: *wherever resolution would select `ejs@2.7.4`,
 install the patched build of exactly that version instead.*
 
-pnpm's existing substitution surface cannot express this:
+Today's override semantics cannot express this:
 
 - **Overrides rewrite declared specs, before resolution**, and a selector
-  matches a declared range by subset. An exact-version key
-  (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) covers only dependencies
-  declared as exactly `2.7.4` — a dependency declared as `^2.7.0` slips
-  past it even when resolution picks `2.7.4`, which is the common case.
+  matches a declared range by subset. An exact-version key covers only
+  dependencies declared as exactly `2.7.4` — a dependency declared as
+  `^2.7.0` slips past it even when resolution picks `2.7.4`, which is the
+  common case.
 - **Widening the selector changes version selection.** No range selector
   matches `^2.7.0` short of the bare name, and a bare-name override forces
   every `ejs` in the graph to the patched `2.7.4` — downgrading a `^2.7.0`
   that would have picked a genuinely fixed `2.7.5`, and freezing the graph
-  to a stale patch after upstream moves on.
+  to a stale patch until someone remembers to remove it.
 
 The condition "resolution picked `2.7.4`" is only knowable *after the
-pick*. That is the gap this RFC fills — with a mechanism deliberately
-separate from overrides, so existing override semantics change in no way.
+pick*. Applying exact-version overrides there gives them a property no
+spec-level encoding has: **they never freeze**. When upstream publishes a
+fixed `2.7.5` and ranges start picking it, the `2.7.4` override simply goes
+inert — the graph moves forward on its own, and the override becomes dead
+config to clean up, not a pin holding the graph back.
 
 ## Detailed Explanation
 
-### The rule
+### The fix
 
-A post-pick substitution rule is an exact original version mapped to an
-alias spec:
+An override with an exact-version selector, `"ejs@2.7.4": <target>`,
+applies in two situations:
+
+1. **To declared specs, by subset** — exactly as today. (The only range
+   that is a subset of `2.7.4` is `2.7.4` itself, so this leg is
+   unchanged.)
+2. **To the picked version, after resolution** — new. The resolver selects
+   a version for a spec exactly as it does today, with every spec-level
+   mechanism (including overrides' existing rewriting) already applied. If
+   the picked `(name, version)` matches an exact-version override, the
+   resolver resolves the override's target and returns *that* result — id,
+   manifest, resolution — under the dependency's original alias. This rides
+   the alias/resolved-identity split that `npm:` specs already use; nothing
+   downstream of the resolver changes.
+
+Rules that keep it predictable:
+
+- **Version selection is never altered.** A `2.7.4` selector has no effect
+  on which version a range picks; it replaces the build of the version that
+  *was* picked. (A target naming a different version is expressible — it is
+  the author's explicit, visible choice, same as today's overrides.)
+- **Applied exactly once.** A substituted result is returned as-is and
+  never re-matched against overrides, so mappings cannot chain or cycle.
+  (npm's RFC 0036 solves the same problem by counting an override's *value*
+  as a match; applied-once is the simpler equivalent.)
+- **Frozen installs are untouched.** Overrides act only when a resolution
+  is made; `--frozen-lockfile` reads no packuments and applies nothing.
+
+### A fix, not a breaking change
+
+The newly covered cases are precisely those where an exact-version override
+previously did **nothing** — silently, with no warning — despite the
+author's evident intent that "this version" means "this version, wherever
+it comes from." npm's own overrides RFC specifies pick-matching intent for
+version-keyed rules, and the miss is regularly reported as a bug. Shipping
+the fix always-on, with a changelog note, is therefore the right default; a
+workspace that genuinely relied on an exact-key override *not* covering
+range-resolved picks (a contrived reading) can key by the declared spec
+instead. No flag, no major-version gate.
+
+### Registry-supplied overrides (pnpr substitute mode)
+
+A pnpr registry in substitute mode serves the patch mapping as an
+annotation on the vulnerable version's packument entry:
 
 ```jsonc
-{ "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4" }
+"2.7.4": {
+  // ...original metadata, original dist...
+  "_pnprPatch": {
+    "patched": "npm:@echo-patch/ejs@2.7.4",
+    "provider": "echo",
+    "fixes": ["GHSA-..."]
+  }
+}
 ```
 
-Semantics:
+To the resolver this is an exact-version override supplied by the registry,
+merged at the **lowest precedence**:
 
-- **Applies after the pick.** The resolver selects a version for a spec
-  exactly as today — overrides and every other spec-level mechanism have
-  already done their work. If the picked `(name, version)` matches a rule,
-  the resolver resolves the rule's target spec and returns *that* result
-  (id, manifest, resolution) under the dependency's original alias, marked
-  `resolvedVia: registry-patch`. This rides the alias/resolved-identity
-  split that `npm:` specs already use; nothing downstream of the resolver
-  changes.
-- **Version selection is never altered.** A rule keyed `ejs@2.7.4` has no
-  effect on which version a range selects; it replaces the build of the
-  version that *was* selected. (A rule whose target names a different
-  version is expressible but is the author's deliberate choice, visible in
-  config.)
-- **Applied exactly once.** A substituted result is returned as-is and
-  never re-matched against the rules, so rules cannot chain or cycle. (npm
-  RFC 0036 solves the same problem by counting an override's *value* as a
-  match; the applied-once rule is the simpler equivalent.)
-- **Frozen installs are untouched.** Rules act only when a resolution is
-  made; `--frozen-lockfile` reads no packuments and consults no rules.
+- if any workspace override claims the same pick, the workspace wins — in
+  particular, a self-mapping (`"ejs@2.7.4": "npm:ejs@2.7.4"`) is the opt-out
+  that keeps the vulnerable original, expressed in ordinary override
+  vocabulary, visible and reviewable;
+- otherwise the annotation applies exactly like the fix above, marked
+  `resolvedVia: registry-patch` in reporting.
 
-### Two sources of rules
-
-1. **Workspace config.** The workspace declares rules directly (config key
-   name is bikeshedding, e.g. `securityPatches.accept` or
-   `substitutions`). Each entry is self-contained — it carries the full
-   mapping — so it works against any registry and pins the patch revision
-   the workspace reviewed. This is the adoption surface for pnpr's
-   *advertise* mode: `pnpm audit` reports available patches (the registry's
-   audit enrichment carries the mapping), and `pnpm audit --fix` copies
-   them into config, reviewable in the PR that introduces them.
-2. **Registry annotations.** A pnpr registry in *substitute* mode serves the
-   mapping as a `_pnprPatch` annotation on the vulnerable version's
-   packument entry. To the resolver an annotation is a registry-supplied
-   rule, applied by default and refused per package (or per provider)
-   through an **ignore list** in workspace config.
-
-When both sources cover the same pick, workspace rules win (they should
-normally agree; a workspace rule pinning an older patch revision than the
-annotation is respected — it was reviewed).
+A client setting governs whether annotations are honored (and from which
+registries); the default is an open question below. Note that client-side
+substitution is a protection layer, not the enforcement boundary — a
+deployment that must prevent vulnerable artifacts entirely uses pnpr's
+registry-side `enforcement: refuse`, under which declining substitution can
+only fail an install, never obtain the vulnerable bytes. pnpm's job there
+is rendering the `403` reason well: the advisory, the patched alternative,
+and the override that would adopt it.
 
 ### Resolution mechanics and cost
 
@@ -105,175 +141,156 @@ matched pick resolves the target: one exact-version resolution against the
 patch-scope packument, which is small (patched versions only), cached like
 any other, and fetched in parallel. The target's packument is genuinely
 needed — the substituted package's **version object** (dependencies, peers,
-`bin`) drives subtree resolution, so the rule is a pointer, not a manifest.
-This is a second resolution of *that dependency*, never of the graph, and
-the original pick is not wasted work: it is the key that selects the rule.
+`bin`) drives subtree resolution, so the override target is a pointer, not
+a manifest. This is a second resolution of *that dependency*, never of the
+graph, and the original pick is not wasted work: it is the key that selects
+the override.
 
 ### Lockfile
 
-Two things are recorded:
+Nothing new is required:
 
-- **The ordinary aliased entry.** The importer/snapshot dependency entry
-  maps `ejs` → `@echo-patch/ejs@2.7.4`; the package entry is keyed by the
+- **The aliased entry** is ordinary: the importer/snapshot dependency entry
+  maps `ejs` → `@echo-patch/ejs@2.7.4`, the package entry is keyed by the
   real identity with a canonical resolution (integrity only, tarball URL
-  recomputed from registry config at install time — nothing host-specific).
-  Byte-for-byte what a hand-written alias override would have produced.
-- **A substitution record** in a dedicated lockfile section: the applied
-  mapping plus its source (workspace rule, or annotation + registry). This
-  is required for *correctness*, not only provenance: without it, the
-  up-to-date check would see `ejs: ^2.7.0` resolved to an alias the
-  workspace's own config does not explain and re-resolve it. The record
-  lets satisfiability checks accept the entry, lets a withdrawn patch
-  re-resolve exactly the affected packages, distinguishes registry
-  substitutions from hand-written config, and tells humans and SBOM tooling
-  why the alias exists.
+  recomputed from registry config) — byte-for-byte what a hand-written
+  alias override produces, because it *is* one.
+- **Workspace-side change detection** is the existing overrides record: pnpm
+  already stores the overrides a resolution used and re-resolves when they
+  change; the fix rides that machinery untouched.
+- **Annotation-produced substitutions** persist the way any locked
+  resolution does: the lockfile is authoritative until an ordinary
+  re-resolution event touches the entry. Whether the up-to-date check needs
+  a minimal marker to avoid spurious re-resolution of an aliased entry it
+  cannot attribute to workspace config — and how a *withdrawn* patch should
+  revert — is left to implementation (see Unresolved Questions); no
+  explanatory lockfile section is proposed.
 
-### Security model
+### `pnpm audit --fix`
 
-Rules and ignore lists are **trusted workspace configuration**, the same
-trust class as overrides — which can already redirect any package to any
-spec, so this feature grants no redirection power that did not exist.
-Client-side substitution is a protection and compatibility layer, **not an
-enforcement boundary**: a deployment whose policy is "the vulnerable
-artifact must not be used" enforces at the registry (pnpr's
-`enforcement: refuse` answers the vulnerable tarball with `403` plus the
-suggested patch, for every client). Under registry enforcement, an ignore
-list can choose failure over substitution but can never obtain the
-vulnerable bytes. pnpm's part of that story is rendering the `403` reason
-body well: name the advisory, the patched alternative, and the config that
-would adopt or ignore it.
-
-### UX surfacing
-
-- `pnpm why ejs` and the install summary show the substitution and its
-  source ("`ejs@2.7.4` → `@echo-patch/ejs@2.7.4` via registry patch
-  (echo)").
-- `pnpm audit` shows available-but-unadopted patches (advertise mode) and
-  the adopted ones' status (a `-sp2` re-issue shows as an available
-  update to an adopted rule; `--fix` updates it).
-- `pnpm licenses`/SBOM tooling see the real patched name, which is the
-  point: provenance is legible wherever the name is recorded.
+pnpr's audit enrichment carries the mapping per vulnerable version.
+`--fix` writes it as an ordinary exact-version override. Because of the
+fix's post-pick semantics this is correct for range-resolved picks, and
+because exact selectors never freeze, the override ages gracefully: a
+provider re-issue (`-sp2`) shows up in the next `pnpm audit` and `--fix`
+updates the entry; an upstream fixed release makes it inert.
 
 ## Rationale and Alternatives
 
-### Extend override semantics instead (exact-version selectors match picks)
+### A separate substitution-rules config (this RFC's earlier draft)
 
-Considered at length in the pnpr RFC's history: let an override whose
-selector is an exact version also match the *picked* version. It is
-strictly additive for exact selectors (the only subset of `2.7.4` is
-`2.7.4` itself), but it silently changes the behavior of existing configs —
-exact-keyed overrides written under today's semantics would start covering
-picks they previously missed — and it entangles adoption with override
-precedence. A separate primitive with its own config surface changes
-nothing that exists and keeps "what substitutes my picks" answerable from
-one place. (If the override extension is ever wanted for its own sake —
-hand-written exact-version overrides that catch range-resolved picks — it
-can be proposed independently; nothing here conflicts.)
+A dedicated post-pick rules list (with accept/ignore lists for registry
+annotations) avoids touching override semantics — but it duplicates
+overrides: a second way to say "replace this package," with its own
+precedence rules, its own opt-out surface, and its own lockfile recording.
+Once the exact-version fix is accepted as a fix, the existing override
+surface provides identical power with none of the parallel machinery, and
+workspace authority over registry annotations falls out of ordinary
+override precedence.
 
-### Apply registry annotations without a workspace-rule counterpart
+### Keep today's override semantics unchanged
 
-Then advertise-mode adoption would have to reuse overrides, which cannot
-express it (Motivation), or a registry-dictated "opt-in posture" flag on
-annotations — rejected because client posture is the workspace's business,
-not the registry's. Self-contained workspace rules keep the primitive
-symmetric: the registry can *suggest* (annotation) and the workspace can
-*declare* (rule), and both meet in the same resolver code path.
+Rejected: spec rewriting cannot see the pick (Motivation), so exact-version
+overrides remain silently inert for the dominant range-declared case, and
+`pnpm audit --fix` has no correct output format.
 
-### Do nothing (blunt overrides)
+### Gate the fix behind a setting or major release
 
-Range-keyed overrides (`"ejs@^2.7.0": "npm:@echo-patch/ejs@2.7.4"`) and
-bare-name overrides work today and remain documented, but they freeze or
-force version selection, silently miss differently-shaped ranges added
-later, and go stale when upstream ships a real fix. Acceptable escape
-hatches; not a mechanism to build a security workflow on.
+Rejected per the "fix, not breaking change" argument above: the changed
+cases are silent no-ops that contradicted author intent, the risk of
+someone depending on the no-op is remote and has a trivial migration (key
+by declared spec), and gating would leave `audit --fix` output broken for
+everyone who has not opted in.
+
+### Registry-dictated application posture
+
+An earlier design had the annotation carry an `apply: default | opt-in`
+field. Rejected: client posture is the workspace's business, not the
+registry's. The registry's two postures are expressed by serving or not
+serving annotations (substitute vs. advertise mode); the workspace's, by
+override precedence.
 
 ## Implementation
 
-All changes are in pnpm (and later pacquet):
-
-1. **Resolver hook.** In `@pnpm/npm-resolver`, after the version pick and
-   before the result is assembled: look up `(name, picked version)` in the
-   effective rule map (workspace rules ∪ annotations − ignore list, with
-   workspace precedence); on a match, resolve the target alias spec and
-   return its result under the original alias with the `resolvedVia`
-   marker. Enforce applied-once by never rule-matching a substitution
-   result.
-2. **Config.** Workspace substitution rules and the ignore list (names are
-   bikeshedding); a setting governing whether registry annotations are
-   honored (and from which registries).
-3. **Lockfile.** The substitution-record section; satisfiability-check
-   integration; re-resolution of affected packages when a recorded rule or
-   annotation disappears or changes.
-4. **`pnpm audit` / `--fix`.** Read the mapping extension field from the
-   enriched bulk-advisories response; render available and adopted patches;
-   `--fix` writes/updates workspace rules.
-5. **Errors and reporting.** Render pnpr's `403` reason body (registry
-   enforcement) with the suggested adoption config; `pnpm why`/summary
-   surfacing.
+1. **Resolver.** In `@pnpm/npm-resolver`, after the version pick: look up
+   `(name, picked version)` in the effective exact-version override map
+   (workspace overrides, then registry annotations if honored); on a match,
+   resolve the target spec and return its result under the original alias
+   with a `resolvedVia` marker. Never re-match a substitution result.
+2. **Overrides plumbing.** Exact-version selectors flow to the resolver
+   (today they live only in the manifest-rewrite hook); precedence:
+   workspace over annotation.
+3. **Settings.** Whether registry annotations are honored, and from which
+   registries.
+4. **`pnpm audit` / `--fix`.** Read the mapping extension from the enriched
+   bulk-advisories response; render available/adopted patches; write and
+   update exact-version overrides.
+5. **Reporting.** `pnpm why`/install summary show substitutions and their
+   source; render pnpr's `403` enforcement body with the adopting override.
 
 Tests should cover, at minimum:
 
-- a range-declared dependency (`^2.7.0`) whose pick lands on a ruled
-  version installing the substituted build, recorded as an alias with a
-  canonical resolution;
-- an exact-pinned declaration behaving identically;
-- version selection unchanged by rules (a range that picks `2.7.5` is not
-  substituted by a `2.7.4` rule);
-- the ignore list suppressing an annotation; workspace rules winning over
-  a conflicting annotation;
-- applied-once: a rule targeting a package that is itself covered by
-  another rule does not chain;
-- `--frozen-lockfile` neither consulting rules nor changing anything;
-- lockfile round-trip: substitution records satisfying the up-to-date
-  check, a withdrawn annotation re-resolving only affected packages, and
-  hand-written-override results distinguishable from substitutions;
-- `pnpm audit --fix` writing rules from the mapping extension and updating
-  them on a patch re-issue;
+- a range-declared dependency (`^2.7.0`) whose pick lands on an
+  exact-version override installing the substituted build, recorded as an
+  alias with a canonical resolution;
+- an exact-pinned declaration behaving identically (and identically to
+  today);
+- version selection unchanged: a range that picks `2.7.5` is untouched by a
+  `2.7.4` override — no freezing;
+- a workspace self-mapping override keeping the vulnerable original against
+  a registry annotation (precedence opt-out);
+- applied-once: no chaining through overrides whose targets are themselves
+  covered by other overrides;
+- `--frozen-lockfile` untouched;
+- overrides-record change detection re-resolving when an exact-version
+  override is added, changed, or removed;
+- `pnpm audit --fix` writing and updating overrides from the mapping
+  extension;
 - rendering of the registry-enforcement `403` reason.
 
 ## Prior Art
 
-- **Go's versioned `replace`** (`replace ejs v2.7.4 => patched v2.7.4`):
-  applies only when MVS selects exactly that version, honored only in the
-  main module — post-selection exact-version substitution with workspace
+- **npm's overrides (RFC 0036)** specify that a version-keyed rule matches
+  "if the named package specifier would be satisfied by the dependency
+  being considered" — pick-matching *intent* — but implement it during
+  arborist tree construction, when nodes may lack versions, producing years
+  of timing bugs (double-install lockfile flapping, fixed only in 11.2.0).
+  Matching at one well-defined point after the pick is the same semantics
+  with the failure mode removed — and npm's rule that an override's value
+  also counts as a match is the analogue of applied-once.
+- **Go's versioned `replace`** (`replace ejs v2.7.4 => patched v2.7.4`)
+  applies only when MVS selects exactly that version and is honored only in
+  the main module: post-selection exact-version substitution with workspace
   authority, alive and standard.
 - **Cargo's `[replace]`**: exact package-id keyed, same-name-same-version
-  source swap on the resolved graph; deprecated in favor of `[patch]`
-  because users needed *version-changing* overrides — a need that stays
-  with pnpm's spec-rewriting overrides here, keeping post-pick substitution
-  for the same-version case where even Cargo's docs equate the two.
-- **npm's overrides (RFC 0036)**: version-keyed overrides that try to match
-  resolved versions during tree construction — a timing entanglement that
-  produced years of bugs (double-install lockfile flapping, fixed only in
-  npm 11.2.0). Substituting at one well-defined point inside a single
-  resolve call is the lesson applied.
-- **yarn's `resolutions`** (Berry): declared-descriptor matching,
-  confirming that every JS package manager's substitution surface is
-  declaration-level today.
+  source swap on the resolved graph; deprecated for `[patch]` because users
+  needed *version-changing* overrides — which stay with pnpm's spec-level
+  overrides here.
+- **yarn's `resolutions`** (Berry) match declared descriptors only,
+  confirming the gap is ecosystem-wide.
 - The registry-side prior art (Seal, Echo, Assured OSS, Socket) is surveyed
   in the pnpr companion RFC.
 
 ## Unresolved Questions and Bikeshedding
 
-- **Config naming and shape.** `securityPatches.accept`/`ignore`,
-  `substitutions`, or something else; per-package vs. per-provider ignore
-  granularity; where the settings live (`pnpm-workspace.yaml`,
-  `package.json#pnpm`).
 - **Default for annotations.** Honored by default when a registry serves
   them, or behind a setting? From any registry, or only configured pnpr
   bases?
+- **Up-to-date semantics for annotation-produced entries.** Does the
+  existing lockfile suffice (authoritative until an ordinary re-resolution
+  event), or does the up-to-date check need a minimal marker so it does not
+  re-resolve an aliased entry it cannot attribute to workspace config? How
+  does a withdrawn patch revert — next re-resolution, or an explicit
+  gesture?
 - **Adoption timing for locked picks.** When a new annotation covers an
   already-locked vulnerable pick, should the next non-frozen re-resolution
   adopt it silently, or should adoption require an explicit gesture
-  (`pnpm update --patches`-style) while only *withdrawn* patches act
-  automatically?
-- **Lockfile section format** for substitution records, and its interplay
-  with the existing `overrides` record.
+  (`pnpm update --patches`-style)?
+- **Parent-scoped selectors.** Should `parent>child@1.2.3` selectors gain
+  the same post-pick behavior, or is graph-wide-by-version the only sane
+  granularity?
 - **Annotation field name.** `_pnprPatch` vs. a vendor-neutral name other
   registries and resolvers could adopt.
-- **Parent-scoped rules.** Should rules support `parent>child@version`
-  scoping like overrides do, or is graph-wide-by-version the right (and
-  only) granularity for security patches?
 - **Server-side resolution parity.** When pnpr's resolve endpoint performs
-  resolution, substitutions arrive pre-applied and marked; the lockfile
-  record must come out identical either way.
+  resolution, substitutions arrive pre-applied and marked; the client-side
+  outcome must be identical either way.

--- a/text/0000-post-pick-substitution.md
+++ b/text/0000-post-pick-substitution.md
@@ -1,0 +1,279 @@
+# Post-pick dependency substitution (patch-aware resolution)
+
+## Summary
+
+pnpm's resolver gains one primitive: a **post-pick substitution rule** —
+"when version resolution picks `name@version`, resolve this alias spec in
+its place." Rules come from two sources: **workspace config** (explicit
+adoption of registry-advertised security patches, written by hand or by
+`pnpm audit --fix`) and **registry annotations** (`_pnprPatch` fields served
+by a pnpr registry in substitute mode, applied by default and refusable per
+package via an ignore list). A substituted dependency is recorded in the
+lockfile as an ordinary alias with a canonical, host-free resolution, plus a
+record explaining why the alias exists. Version selection itself never
+changes — only which *build* of the selected version is installed.
+
+This is the client half of the pnpr patch-provider design
+([`pnpr/text/0000-patch-providers.md`](../pnpr/text/0000-patch-providers.md));
+the registry half (patch scopes, signed manifests, annotation serving, audit
+enrichment, registry-side enforcement) is specified there. This RFC is
+useful on its own — workspace-declared rules require no pnpr — but its
+motivating consumer is registry-delivered security patches.
+
+## Motivation
+
+Vendors such as Echo and Seal ship security-patched builds of vulnerable
+package versions that keep the **original version number** under a distinct
+package name (`@echo-patch/ejs@2.7.4` is the patched build of `ejs@2.7.4`).
+Adopting such a patch means: *wherever resolution would select `ejs@2.7.4`,
+install the patched build of exactly that version instead.*
+
+pnpm's existing substitution surface cannot express this:
+
+- **Overrides rewrite declared specs, before resolution**, and a selector
+  matches a declared range by subset. An exact-version key
+  (`"ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4"`) covers only dependencies
+  declared as exactly `2.7.4` — a dependency declared as `^2.7.0` slips
+  past it even when resolution picks `2.7.4`, which is the common case.
+- **Widening the selector changes version selection.** No range selector
+  matches `^2.7.0` short of the bare name, and a bare-name override forces
+  every `ejs` in the graph to the patched `2.7.4` — downgrading a `^2.7.0`
+  that would have picked a genuinely fixed `2.7.5`, and freezing the graph
+  to a stale patch after upstream moves on.
+
+The condition "resolution picked `2.7.4`" is only knowable *after the
+pick*. That is the gap this RFC fills — with a mechanism deliberately
+separate from overrides, so existing override semantics change in no way.
+
+## Detailed Explanation
+
+### The rule
+
+A post-pick substitution rule is an exact original version mapped to an
+alias spec:
+
+```jsonc
+{ "ejs@2.7.4": "npm:@echo-patch/ejs@2.7.4" }
+```
+
+Semantics:
+
+- **Applies after the pick.** The resolver selects a version for a spec
+  exactly as today — overrides and every other spec-level mechanism have
+  already done their work. If the picked `(name, version)` matches a rule,
+  the resolver resolves the rule's target spec and returns *that* result
+  (id, manifest, resolution) under the dependency's original alias, marked
+  `resolvedVia: registry-patch`. This rides the alias/resolved-identity
+  split that `npm:` specs already use; nothing downstream of the resolver
+  changes.
+- **Version selection is never altered.** A rule keyed `ejs@2.7.4` has no
+  effect on which version a range selects; it replaces the build of the
+  version that *was* selected. (A rule whose target names a different
+  version is expressible but is the author's deliberate choice, visible in
+  config.)
+- **Applied exactly once.** A substituted result is returned as-is and
+  never re-matched against the rules, so rules cannot chain or cycle. (npm
+  RFC 0036 solves the same problem by counting an override's *value* as a
+  match; the applied-once rule is the simpler equivalent.)
+- **Frozen installs are untouched.** Rules act only when a resolution is
+  made; `--frozen-lockfile` reads no packuments and consults no rules.
+
+### Two sources of rules
+
+1. **Workspace config.** The workspace declares rules directly (config key
+   name is bikeshedding, e.g. `securityPatches.accept` or
+   `substitutions`). Each entry is self-contained — it carries the full
+   mapping — so it works against any registry and pins the patch revision
+   the workspace reviewed. This is the adoption surface for pnpr's
+   *advertise* mode: `pnpm audit` reports available patches (the registry's
+   audit enrichment carries the mapping), and `pnpm audit --fix` copies
+   them into config, reviewable in the PR that introduces them.
+2. **Registry annotations.** A pnpr mount in *substitute* mode serves the
+   mapping as a `_pnprPatch` annotation on the vulnerable version's
+   packument entry. To the resolver an annotation is a registry-supplied
+   rule, applied by default and refused per package (or per provider)
+   through an **ignore list** in workspace config.
+
+When both sources cover the same pick, workspace rules win (they should
+normally agree; a workspace rule pinning an older patch revision than the
+annotation is respected — it was reviewed).
+
+### Resolution mechanics and cost
+
+Matching is a map lookup per pick — free for the unpatched majority. A
+matched pick resolves the target: one exact-version resolution against the
+patch-scope packument, which is small (patched versions only), cached like
+any other, and fetched in parallel. The target's packument is genuinely
+needed — the substituted package's **version object** (dependencies, peers,
+`bin`) drives subtree resolution, so the rule is a pointer, not a manifest.
+This is a second resolution of *that dependency*, never of the graph, and
+the original pick is not wasted work: it is the key that selects the rule.
+
+### Lockfile
+
+Two things are recorded:
+
+- **The ordinary aliased entry.** The importer/snapshot dependency entry
+  maps `ejs` → `@echo-patch/ejs@2.7.4`; the package entry is keyed by the
+  real identity with a canonical resolution (integrity only, tarball URL
+  recomputed from registry config at install time — nothing host-specific).
+  Byte-for-byte what a hand-written alias override would have produced.
+- **A substitution record** in a dedicated lockfile section: the applied
+  mapping plus its source (workspace rule, or annotation + registry). This
+  is required for *correctness*, not only provenance: without it, the
+  up-to-date check would see `ejs: ^2.7.0` resolved to an alias the
+  workspace's own config does not explain and re-resolve it. The record
+  lets satisfiability checks accept the entry, lets a withdrawn patch
+  re-resolve exactly the affected packages, distinguishes registry
+  substitutions from hand-written config, and tells humans and SBOM tooling
+  why the alias exists.
+
+### Security model
+
+Rules and ignore lists are **trusted workspace configuration**, the same
+trust class as overrides — which can already redirect any package to any
+spec, so this feature grants no redirection power that did not exist.
+Client-side substitution is a protection and compatibility layer, **not an
+enforcement boundary**: a deployment whose policy is "the vulnerable
+artifact must not be used" enforces at the registry (pnpr's
+`enforcement: refuse` answers the vulnerable tarball with `403` plus the
+suggested patch, for every client). Under registry enforcement, an ignore
+list can choose failure over substitution but can never obtain the
+vulnerable bytes. pnpm's part of that story is rendering the `403` reason
+body well: name the advisory, the patched alternative, and the config that
+would adopt or ignore it.
+
+### UX surfacing
+
+- `pnpm why ejs` and the install summary show the substitution and its
+  source ("`ejs@2.7.4` → `@echo-patch/ejs@2.7.4` via registry patch
+  (echo)").
+- `pnpm audit` shows available-but-unadopted patches (advertise mode) and
+  the adopted ones' status (a `-sp2` re-issue shows as an available
+  update to an adopted rule; `--fix` updates it).
+- `pnpm licenses`/SBOM tooling see the real patched name, which is the
+  point: provenance is legible wherever the name is recorded.
+
+## Rationale and Alternatives
+
+### Extend override semantics instead (exact-version selectors match picks)
+
+Considered at length in the pnpr RFC's history: let an override whose
+selector is an exact version also match the *picked* version. It is
+strictly additive for exact selectors (the only subset of `2.7.4` is
+`2.7.4` itself), but it silently changes the behavior of existing configs —
+exact-keyed overrides written under today's semantics would start covering
+picks they previously missed — and it entangles adoption with override
+precedence. A separate primitive with its own config surface changes
+nothing that exists and keeps "what substitutes my picks" answerable from
+one place. (If the override extension is ever wanted for its own sake —
+hand-written exact-version overrides that catch range-resolved picks — it
+can be proposed independently; nothing here conflicts.)
+
+### Apply registry annotations without a workspace-rule counterpart
+
+Then advertise-mode adoption would have to reuse overrides, which cannot
+express it (Motivation), or a registry-dictated "opt-in posture" flag on
+annotations — rejected because client posture is the workspace's business,
+not the registry's. Self-contained workspace rules keep the primitive
+symmetric: the registry can *suggest* (annotation) and the workspace can
+*declare* (rule), and both meet in the same resolver code path.
+
+### Do nothing (blunt overrides)
+
+Range-keyed overrides (`"ejs@^2.7.0": "npm:@echo-patch/ejs@2.7.4"`) and
+bare-name overrides work today and remain documented, but they freeze or
+force version selection, silently miss differently-shaped ranges added
+later, and go stale when upstream ships a real fix. Acceptable escape
+hatches; not a mechanism to build a security workflow on.
+
+## Implementation
+
+All changes are in pnpm (and later pacquet):
+
+1. **Resolver hook.** In `@pnpm/npm-resolver`, after the version pick and
+   before the result is assembled: look up `(name, picked version)` in the
+   effective rule map (workspace rules ∪ annotations − ignore list, with
+   workspace precedence); on a match, resolve the target alias spec and
+   return its result under the original alias with the `resolvedVia`
+   marker. Enforce applied-once by never rule-matching a substitution
+   result.
+2. **Config.** Workspace substitution rules and the ignore list (names are
+   bikeshedding); a setting governing whether registry annotations are
+   honored (and from which registries).
+3. **Lockfile.** The substitution-record section; satisfiability-check
+   integration; re-resolution of affected packages when a recorded rule or
+   annotation disappears or changes.
+4. **`pnpm audit` / `--fix`.** Read the mapping extension field from the
+   enriched bulk-advisories response; render available and adopted patches;
+   `--fix` writes/updates workspace rules.
+5. **Errors and reporting.** Render pnpr's `403` reason body (registry
+   enforcement) with the suggested adoption config; `pnpm why`/summary
+   surfacing.
+
+Tests should cover, at minimum:
+
+- a range-declared dependency (`^2.7.0`) whose pick lands on a ruled
+  version installing the substituted build, recorded as an alias with a
+  canonical resolution;
+- an exact-pinned declaration behaving identically;
+- version selection unchanged by rules (a range that picks `2.7.5` is not
+  substituted by a `2.7.4` rule);
+- the ignore list suppressing an annotation; workspace rules winning over
+  a conflicting annotation;
+- applied-once: a rule targeting a package that is itself covered by
+  another rule does not chain;
+- `--frozen-lockfile` neither consulting rules nor changing anything;
+- lockfile round-trip: substitution records satisfying the up-to-date
+  check, a withdrawn annotation re-resolving only affected packages, and
+  hand-written-override results distinguishable from substitutions;
+- `pnpm audit --fix` writing rules from the mapping extension and updating
+  them on a patch re-issue;
+- rendering of the registry-enforcement `403` reason.
+
+## Prior Art
+
+- **Go's versioned `replace`** (`replace ejs v2.7.4 => patched v2.7.4`):
+  applies only when MVS selects exactly that version, honored only in the
+  main module — post-selection exact-version substitution with workspace
+  authority, alive and standard.
+- **Cargo's `[replace]`**: exact package-id keyed, same-name-same-version
+  source swap on the resolved graph; deprecated in favor of `[patch]`
+  because users needed *version-changing* overrides — a need that stays
+  with pnpm's spec-rewriting overrides here, keeping post-pick substitution
+  for the same-version case where even Cargo's docs equate the two.
+- **npm's overrides (RFC 0036)**: version-keyed overrides that try to match
+  resolved versions during tree construction — a timing entanglement that
+  produced years of bugs (double-install lockfile flapping, fixed only in
+  npm 11.2.0). Substituting at one well-defined point inside a single
+  resolve call is the lesson applied.
+- **yarn's `resolutions`** (Berry): declared-descriptor matching,
+  confirming that every JS package manager's substitution surface is
+  declaration-level today.
+- The registry-side prior art (Seal, Echo, Assured OSS, Socket) is surveyed
+  in the pnpr companion RFC.
+
+## Unresolved Questions and Bikeshedding
+
+- **Config naming and shape.** `securityPatches.accept`/`ignore`,
+  `substitutions`, or something else; per-package vs. per-provider ignore
+  granularity; where the settings live (`pnpm-workspace.yaml`,
+  `package.json#pnpm`).
+- **Default for annotations.** Honored by default when a registry serves
+  them, or behind a setting? From any registry, or only configured pnpr
+  bases?
+- **Adoption timing for locked picks.** When a new annotation covers an
+  already-locked vulnerable pick, should the next non-frozen re-resolution
+  adopt it silently, or should adoption require an explicit gesture
+  (`pnpm update --patches`-style) while only *withdrawn* patches act
+  automatically?
+- **Lockfile section format** for substitution records, and its interplay
+  with the existing `overrides` record.
+- **Annotation field name.** `_pnprPatch` vs. a vendor-neutral name other
+  registries and resolvers could adopt.
+- **Parent-scoped rules.** Should rules support `parent>child@version`
+  scoping like overrides do, or is graph-wide-by-version the right (and
+  only) granularity for security patches?
+- **Server-side resolution parity.** When pnpr's resolve endpoint performs
+  resolution, substitutions arrive pre-applied and marked; the lockfile
+  record must come out identical either way.

--- a/text/0000-post-pick-substitution.md
+++ b/text/0000-post-pick-substitution.md
@@ -88,7 +88,7 @@ Semantics:
    *advertise* mode: `pnpm audit` reports available patches (the registry's
    audit enrichment carries the mapping), and `pnpm audit --fix` copies
    them into config, reviewable in the PR that introduces them.
-2. **Registry annotations.** A pnpr mount in *substitute* mode serves the
+2. **Registry annotations.** A pnpr registry in *substitute* mode serves the
    mapping as a `_pnprPatch` annotation on the vulnerable version's
    packument entry. To the resolver an annotation is a registry-supplied
    rule, applied by default and refused per package (or per provider)


### PR DESCRIPTION
## Summary

Two RFCs, registry half and client half of one design, built on the pnpr registries model (#16).

### `pnpr/text/0000-patch-providers.md` — registry side

Registry-level delivery of security-patched package versions from vendors such as Echo, Seal Security, and Socket, in two shapes:

- **Vendor as origin** — the vendor's registry as an ordinary upstream registry; the coherent home for full same-version patching (Echo) and same-name `-spN` packuments (Seal).
- **Patch scope** — the provider publishes patched artifacts under its own namespace (`@echo-patch/ejs@2.7.4`, keeping the *original* version number). The patch-source registry declares that scope in its `packages:` map (namespace, request filter, and access policy in one declaration, per RFC #17), enforced on every path to it. A signed, pinned patch manifest ties the two names together (integrity enforced at pnpr's serving path — the provider's infrastructure is an uncontrolled origin), and a per-registry `patching:` policy applies it in one of two modes. **Both end in an ordinary exact-version override applied to the picked version** (the companion RFC's semantics fix):
  - **advertise** — no annotations; patches discovered via audit-endpoint enrichment (which carries the mapping) and adopted as plain workspace overrides, written by hand or by `pnpm audit --fix`. Post-pick matching makes the exact key cover range-resolved picks, and the override never freezes: when upstream ships a fixed `2.7.5`, it goes inert.
  - **substitute** — pnpr annotates the vulnerable version's packument entry (`_pnprPatch`, on egress over a pristine cache, inert for unaware clients); the resolver honors it as a **registry-supplied override at lowest precedence**. Opt-out is ordinary override precedence: a workspace self-mapping override keeps the original.
- **Client choice is not a security boundary**: with `enforcement: refuse`, the tarball route refuses the manifest-covered vulnerable artifact for every client with a `403` naming the patched alternative.

No new registry kind, no new client config surface, no new lockfile machinery (workspace adoptions ride the existing overrides record). Advisory identity mapping closes the new-CVE blind spot. Rejected alternatives each recorded with their failure mode: prerelease grafting, fetch-time byte substitution, dist rewriting, unchanged override semantics, a separate substitution-rules config, a standalone patched-versions document, registry-dictated apply posture.

### `text/0000-post-pick-substitution.md` — pnpm side (companion)

1. **A semantics fix to overrides**: an exact-version selector also matches the **picked** version. Framed as a fix, always on — the newly covered cases are ones where the override silently did nothing, contrary to author intent (npm RFC 0036 specifies pick-matching intent; its mid-tree implementation is the cautionary tale). Applied exactly once; version selection never changes; exact-version overrides gain the never-freezes property.
2. **Registry-supplied overrides**: substitute-mode `_pnprPatch` annotations honored at lowest precedence beneath workspace overrides.

Lockfile: nothing new — aliased entries are ordinary, workspace overrides are already recorded and change-detected; whether annotation-produced aliases need a minimal up-to-date marker is an open implementation question. `pnpm audit --fix` writes plain overrides. Prior art: Go's versioned `replace`, Cargo's `[replace]`, npm RFC 0036, yarn resolutions.

Independent of, but composable with, the package-screening RFC (#15).