### PR TITLE
RFC: define macOS and Windows shared artifact tags

### DIFF
--- a/text/0007-shared-side-effects-cache.md
+++ b/text/0007-shared-side-effects-cache.md
@@ -94,6 +94,14 @@ The client presents an ordered set of tags it supports and selects the best offe
 
 **Shipped in v0.** The vocabulary is deliberately one narrow tagged form — `pnpm:v1:linux-<architecture>-node<major>-glibc<major>.<minor>`, with `architecture` in `{x64, arm64}` and every numeric component a canonical unsigned decimal — plus `universal`. A consumer generates its glibc floors down to minor zero, most recent first, so a glibc 2.3 host advertises `glibc2.3`, `glibc2.2`, `glibc2.1`, `glibc2.0`; matching is then exact string membership in that ordered set, and a 2.1-floor artifact serves the 2.3 consumer without the client parsing version ranges it was never given. Tagged matches beat `universal`, and equal-rank variants are ordered by ascending signed-envelope digest so selection is deterministic rather than dependent on response order. Other platforms and libc families are simply absent from the vocabulary — the same "absence of information is not permission" rule applied to the vocabulary itself, since the alternative is a client guessing what a musl tag it has never seen implies.
 
+**macOS vocabulary.** macOS adds a new form to the v1 vocabulary without changing the shipped Linux tags: `pnpm:v1:darwin-<architecture>-node<major>-macos<major>.<minor>`, again with `architecture` in `{x64, arm64}` and canonical unsigned decimal components. The macOS version is the product version, not the Darwin kernel release. Patch releases do not create a new compatibility boundary; `15.5.1` is represented as `macos15.5`.
+
+The version in an artifact tag is a minimum runtime. A macOS consumer presents one tag containing its current product version, and an artifact matches when the schema, operating system, architecture, and Node major are equal and the consumer's `(major, minor)` pair is greater than or equal to the artifact's. When several variants match, the greatest minimum version wins; `universal` remains the final fallback. This makes the floor comparison explicit instead of expanding every historical macOS minor release into the consumer's tag list, which would make the fingerprint grow without bound as macOS releases accrue.
+
+Organization-mode publication uses the builder's current macOS product version as the floor. That is conservative when the produced Mach-O files declare an older deployment target, but never broadens their claimed compatibility beyond the builder on which they ran. A future publisher tool may inspect every Mach-O deployment target and advertise an older floor, but it must not infer one merely from the SDK or toolchain version. If the product version cannot be determined, the client neither publishes nor restores a tagged macOS artifact.
+
+The consumer platform fingerprint remains SHA-256 over its canonical supported-tag list. A macOS consumer therefore fingerprints its one exact tag, so changing macOS minor versions changes the fingerprint. Existing clients reject the unfamiliar `darwin` form as a miss, while v1 Linux matching and fingerprints remain byte-for-byte unchanged.
+
 ### Fetching
 
 **The registry is the default channel; the signature is the authority.** An artifact is looked up at the registry a package resolved from, which is what makes per-registry auth, certificates, proxies, and the registry-qualified lockfile keys work unchanged. But acceptance turns on the signature, not on which host served the bytes — so a mirror, a proxying pnpr, or a publisher's own distribution point can serve an artifact the client will accept, and a registry serving one it cannot verify has gained nothing.
@@ -277,7 +285,7 @@ Ordering: the input-key/compatibility split is the prerequisite, and its format 
 - **Persistent origin metadata and quarantine.** Without them a remote artifact cannot be cached locally between installs, and a poisoned blob is re-fetched on every one.
 - **Key distribution, rotation, and revocation.** v0 distributes public keys by environment variable and has no revocation at all.
 - **Publisher mode.** Discovery, the attestation subject, and the authorization policy for who may attest artifacts on a package's behalf. The wire format already carries the owner arm.
-- **Platforms beyond Linux/glibc.** A vocabulary extension rather than new machinery, which is the point of having designed the vocabulary first.
+- **Platforms beyond Linux/glibc.** The macOS vocabulary is specified above. Windows and additional Linux libc families still need their own compatibility boundaries before implementation.
 - **Multi-channel lookup.** Specified above, unexercised: a single-server deployment has no second channel to group by.
 - **The batching benchmark**, which now has a real implementation to measure instead of two assertions.
 

--- a/text/0007-shared-side-effects-cache.md
+++ b/text/0007-shared-side-effects-cache.md
@@ -102,6 +102,12 @@ Organization-mode publication uses the builder's current macOS product version a
 
 The consumer platform fingerprint remains SHA-256 over its canonical supported-tag list. A macOS consumer therefore fingerprints its one exact tag, so changing macOS minor versions changes the fingerprint. Existing clients reject the unfamiliar `darwin` form as a miss, while v1 Linux matching and fingerprints remain byte-for-byte unchanged.
 
+**Windows vocabulary.** Windows adds `pnpm:v1:win32-<architecture>-node<major>-windows<major>.<minor>.<build>` to the same v1 vocabulary, with `architecture` in `{x64, arm64}` and canonical unsigned decimal components. The version is the NT kernel version returned by the operating system, not a marketing name such as Windows 10, Windows 11, or Windows Server 2025. Keeping the build component is necessary because supported Windows releases commonly share the same `10.0` major and minor version.
+
+The Windows version is also a minimum runtime. A consumer presents one exact tag; an artifact matches when the schema, operating system, architecture, and Node major are equal and the consumer's `(major, minor, build)` tuple is greater than or equal to the artifact's. The greatest matching floor wins, followed by `universal`. This is deliberately more conservative than the platform-and-architecture convention used by published Node prebuilds: Windows normally preserves application compatibility, but an arbitrary install script can still produce a binary that calls APIs introduced by its build host.
+
+Organization-mode publication uses the builder's current NT kernel version as the floor. A future publisher tool may derive an older floor by inspecting and testing its complete output, but must not claim one from the compiler or SDK version alone. If the kernel version cannot be determined, the client neither publishes nor restores a tagged Windows artifact. A Windows consumer fingerprints its one exact tag, so an OS upgrade that changes the kernel build gets a distinct pin namespace. Existing v1 Linux and macOS tags and fingerprints are unchanged, and clients that predate this form treat it as a miss.
+
 ### Fetching
 
 **The registry is the default channel; the signature is the authority.** An artifact is looked up at the registry a package resolved from, which is what makes per-registry auth, certificates, proxies, and the registry-qualified lockfile keys work unchanged. But acceptance turns on the signature, not on which host served the bytes — so a mirror, a proxying pnpr, or a publisher's own distribution point can serve an artifact the client will accept, and a registry serving one it cannot verify has gained nothing.
@@ -285,7 +291,7 @@ Ordering: the input-key/compatibility split is the prerequisite, and its format 
 - **Persistent origin metadata and quarantine.** Without them a remote artifact cannot be cached locally between installs, and a poisoned blob is re-fetched on every one.
 - **Key distribution, rotation, and revocation.** v0 distributes public keys by environment variable and has no revocation at all.
 - **Publisher mode.** Discovery, the attestation subject, and the authorization policy for who may attest artifacts on a package's behalf. The wire format already carries the owner arm.
-- **Platforms beyond Linux/glibc.** The macOS vocabulary is specified above. Windows and additional Linux libc families still need their own compatibility boundaries before implementation.
+- **Additional Linux libc families.** musl and other libc families still need their own compatibility boundaries before implementation.
 - **Multi-channel lookup.** Specified above, unexercised: a single-server deployment has no second channel to group by.
 - **The batching benchmark**, which now has a real implementation to measure instead of two assertions.
 


### PR DESCRIPTION
Defines the macOS and Windows compatibility vocabularies for the shared side-effects cache tracked by pnpm/pnpm#13771.

- adds additive v1 tags for Darwin product-version floors and Windows NT kernel-version floors
- makes each artifact version an explicit minimum runtime and selects the greatest compatible floor
- fingerprints each consumer's exact OS version without expanding an ever-growing historical tag list
- leaves the shipped Linux/glibc tags and fingerprints unchanged; older clients safely treat the new forms as misses

Both formats retain OS release precision because pnpm publishes the builder's current runtime as a conservative floor. Windows includes the kernel build because supported Windows releases commonly share the same `10.0` major and minor version.

---
Written by an agent (Codex, GPT-5).
